### PR TITLE
Abhishek/4.3.0/lr d1 pro

### DIFF
--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -7395,6 +7395,7 @@ class AutoTestCopter(AutoTest):
             ("benewake_tf03", 27),
             ("gyus42v2", 31),
             ("teraranger_serial", 35),
+            ("ainstein_lrd1_pro", 42),
         ]
         while len(drivers):
             do_drivers = drivers[0:3]

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -461,6 +461,20 @@ struct PACKED log_RFND {
 };
 
 /*
+  Logging for LRD1 Pro QCCCBBB
+*/
+struct PACKED log_LRD1 {
+    LOG_PACKET_HEADER;
+    uint64_t time_us;
+    uint16_t dist_24_cm;
+    uint16_t dist_60_cm;
+    uint16_t dist_int_cm;
+    uint8_t snr_24;
+    uint8_t snr_60;
+    uint8_t snr_int;
+};
+
+/*
   terrain log structure
  */
 struct PACKED log_TERRAIN {
@@ -1253,6 +1267,8 @@ LOG_STRUCTURE_FROM_CAMERA \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
     { LOG_RFND_MSG, sizeof(log_RFND), \
       "RFND", "QBCBB", "TimeUS,Instance,Dist,Stat,Orient", "s#m--", "F-B--", true }, \
+    { LOG_LRD1_MSG, sizeof(log_LRD1), \
+      "LRD1", "QCCCBBB", "TimeUS,Dis24,Dis60,DisInt,Snr24,Snr60,SnrInt", "smmm---", "FBBB---", true }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
       "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     LOG_STRUCTURE_FROM_BEACON                                       \
@@ -1374,6 +1390,8 @@ enum LogMessages : uint8_t {
     LOG_ARSP_MSG,
     LOG_IDS_FROM_RPM,
     LOG_RFND_MSG,
+    // Adding new log for LRD1 Pro Abhishek Saxena
+    LOG_LRD1_MSG,
     LOG_MAV_STATS,
     LOG_FORMAT_UNITS_MSG,
     LOG_UNIT_MSG,

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -461,20 +461,6 @@ struct PACKED log_RFND {
 };
 
 /*
-  Logging for LRD1 Pro QCCCBBB
-*/
-struct PACKED log_LRD1 {
-    LOG_PACKET_HEADER;
-    uint64_t time_us;
-    uint16_t dist_24_cm;
-    uint16_t dist_60_cm;
-    uint16_t dist_int_cm;
-    uint8_t snr_24;
-    uint8_t snr_60;
-    uint8_t snr_int;
-};
-
-/*
   terrain log structure
  */
 struct PACKED log_TERRAIN {
@@ -1267,8 +1253,6 @@ LOG_STRUCTURE_FROM_CAMERA \
       "MODE", "QMBB",         "TimeUS,Mode,ModeNum,Rsn", "s---", "F---" }, \
     { LOG_RFND_MSG, sizeof(log_RFND), \
       "RFND", "QBCBB", "TimeUS,Instance,Dist,Stat,Orient", "s#m--", "F-B--", true }, \
-    { LOG_LRD1_MSG, sizeof(log_LRD1), \
-      "LRD1", "QCCCBBB", "TimeUS,Dis24,Dis60,DisInt,Snr24,Snr60,SnrInt", "smmm---", "FBBB---", true }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
       "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     LOG_STRUCTURE_FROM_BEACON                                       \
@@ -1390,8 +1374,6 @@ enum LogMessages : uint8_t {
     LOG_ARSP_MSG,
     LOG_IDS_FROM_RPM,
     LOG_RFND_MSG,
-    // Adding new log for LRD1 Pro Abhishek Saxena
-    LOG_LRD1_MSG,
     LOG_MAV_STATS,
     LOG_FORMAT_UNITS_MSG,
     LOG_UNIT_MSG,

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -472,6 +472,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
 #endif
         break;
     case Type::Ainstein_LRD1_Pro:
+    case Type::Ainstein_LR_D1:
 #if AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED
         serial_create_fn = AP_RangeFinder_Ainstein_LRD1_Pro::create;
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -471,7 +471,7 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         serial_create_fn = AP_RangeFinder_LightWareSerial::create;
 #endif
         break;
-    case Type::Ainstein_LR_D1:
+    case Type::Ainstein_LRD1_Pro:
 #if AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED
         serial_create_fn = AP_RangeFinder_Ainstein_LRD1_Pro::create;
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -51,6 +51,7 @@
 #include "AP_RangeFinder_MSP.h"
 #include "AP_RangeFinder_USD1_CAN.h"
 #include "AP_RangeFinder_Benewake_CAN.h"
+#include "AP_RangeFinder_Ainstein_LRD1_Pro.h"
 
 #include <AP_BoardConfig/AP_BoardConfig.h>
 #include <AP_Logger/AP_Logger.h>
@@ -468,6 +469,11 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
     case Type::LWSER:
 #if AP_RANGEFINDER_LIGHTWARE_SERIAL_ENABLED
         serial_create_fn = AP_RangeFinder_LightWareSerial::create;
+#endif
+        break;
+    case Type::Ainstein_LRD1_Pro:
+#if AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED
+        serial_create_fn = AP_RangeFinder_Ainstein_LRD1_Pro::create;
 #endif
         break;
     case Type::LEDDARONE:

--- a/libraries/AP_RangeFinder/AP_RangeFinder.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.cpp
@@ -471,7 +471,6 @@ void RangeFinder::detect_instance(uint8_t instance, uint8_t& serial_instance)
         serial_create_fn = AP_RangeFinder_LightWareSerial::create;
 #endif
         break;
-    case Type::Ainstein_LRD1_Pro:
     case Type::Ainstein_LR_D1:
 #if AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED
         serial_create_fn = AP_RangeFinder_Ainstein_LRD1_Pro::create;

--- a/libraries/AP_RangeFinder/AP_RangeFinder.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder.h
@@ -103,6 +103,7 @@ public:
         USD1_CAN = 33,
         Benewake_CAN = 34,
         TeraRanger_Serial = 35,
+        Ainstein_LRD1_Pro = 42,
         SIM = 100,
     };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -13,20 +13,22 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-
 #include "AP_RangeFinder_Ainstein_LRD1_Pro.h"
 
 #if AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED
 
 #include <GCS_MAVLink/GCS.h>
+#include <ctype.h>
 
 // sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
 uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
 {
     uint16_t ret = 0;
-    for (uint32_t i=0; i<count; i++) {
+    for (uint32_t i = 0; i < count; i++)
+    {
         ret += data[i];
     }
+    // GCS_SEND_TEXT(MAV_SEVERITY_ERROR,"Abhishek :: CheckSum :: (%f)", float(ret));
     return ret;
 }
 
@@ -37,113 +39,144 @@ uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count)
     return crc_sum_of_bytes_16(data, count) & 0xFF;
 }
 
-
 // get_reading - read a value from the sensor
 bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
 {
-    if (uart == nullptr || uart->available() == 0) {
+    if (uart == nullptr)
+    {
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Abhishek :: get_reading UART Connection NULL");
+    }
+    if (uart == nullptr || uart->available() == 0)
+    {
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Abhishek :: get_reading connection (%f)", float(uart->available()));
         return false;
     }
 
     bool has_data = false;
+    int16_t nbytes = uart->available();
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Data Length:: %f", float(nbytes));
+    while (nbytes-- > PACKET_SIZE)
+    {
+        int16_t r = uart->read();
+        uint8_t c = (uint8_t)r;
 
-    uint32_t available = MAX(uart->available(), static_cast<unsigned int>(PACKET_SIZE*4));
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Packet available :: %lu ", available);
-    while (available >= PACKET_SIZE) {
-        // ---------------
-        // Sync up with the header
         const uint8_t header[] = {
-            0xEB,   // Header MSB
-            0x90,   // Header LSB
-            0x00   // Device ID
+            0xEB, // Header MSB
+            0x90, // Header LSB
+            0x00  // Device ID
         };
-        for (uint8_t i = 0; i<ARRAY_SIZE(header); i++) {
-            // available--;
-            while (uart->read() != header[i]) {
-                available--;
+        for (uint8_t i = 0; i < ARRAY_SIZE(header); i++)
+        {
+            while (uart->read() != header[i] && nbytes >= PACKET_SIZE)
+            {
+                nbytes--;
                 continue;
             }
         }
+        /*
+            header is aligned!
+            Get the next 28 bytes
+        */
 
         const uint8_t rest_of_packet_size = (PACKET_SIZE - ARRAY_SIZE(header));
-        if (available < rest_of_packet_size) {  
+        if (nbytes < rest_of_packet_size)
+        {
             return false;
         }
 
-        // 
-        // header is aligned!
-        // ---------------
-        
         /*
-        This is reading from the uart and storing in the buffer
-        */ 
+            This is reading from the uart and storing in the buffer
+        */
         uint8_t buffer[rest_of_packet_size];
-        available -= uart->read(buffer, ARRAY_SIZE(buffer));
+        nbytes -= uart->read(buffer, ARRAY_SIZE(buffer));
 
         /*
-        Validating the : 
-        Checksum: (data4+data5+…+data30+data31) bitwise-AND
-        with 0xFF
+            Validating the :
+            Checksum: (data4+data5+…+data30+data31) bitwise-AND
+            with 0xFF
         */
-        const uint8_t checksum = buffer[ARRAY_SIZE(buffer)-1]; // last byte is a checksum
-        if (crc_sum_of_bytes(buffer, ARRAY_SIZE(buffer)-1) != checksum) {
+        const uint8_t checksum = buffer[ARRAY_SIZE(buffer) - 1]; // last byte is a checksum
+        if (crc_sum_of_bytes(buffer, ARRAY_SIZE(buffer) - 1) != checksum)
+        {
             // bad Checksum
             continue;
         }
-        
+
         /*
-        This is alert for any malfunction set in data5 and data6
-        since buffer is starts from data 4 (header allign) so buffer[1] buffer[2]
-        0x0000: Normal
-        Others: Malfunction Alert
+            Checking that the required buffer is 28 bytes to read
+        */
+        if (buffer[0] != 0x1C)
+        {
+            continue;
+        }
+        /*
+            This is alert for any malfunction set in data5 and data6
+            since buffer is starts from data 4 (header allign) so buffer[1] buffer[2]
+            0x0000: Normal
+            Others: Malfunction Alert
         */
         const uint8_t malfunction_alert = UINT16_VALUE(buffer[1], buffer[2]);
 
         /*
-        Reading data packets:
-        24 Gz:
-        Altitude : data7 data8 or buffer[3] buffer[4]
-        SNR:       data9 or buffer[5]
-        Velocity:  data10 data 11 or buffer[6] buffer [7]
-        60 Gz :
-        Altitude : data12 data13 or buffer[8] buffer[9]
-        SNR:       data14 or buffer[10]
-        Velocity:  data15 data 16 or buffer[11] buffer [12]
-        Integrated:
-        Altitude : data17 data18 or buffer[13] buffer[14]
-        SNR:       data19 or buffer[15]
-        Velocity:  data20 data 21 or buffer[16] buffer [17]
+            Reading data packets:
+            24 Gz:
+            Altitude : data7 data8 or buffer[3] buffer[4]
+            SNR:       data9 or buffer[5]
+            Velocity:  data10 data 11 or buffer[6] buffer [7]
+            60 Gz :
+            Altitude : data12 data13 or buffer[8] buffer[9]
+            SNR:       data14 or buffer[10]
+            Velocity:  data15 data 16 or buffer[11] buffer [12]
+            Integrated:
+            Altitude : data17 data18 or buffer[13] buffer[14]
+            SNR:       data19 or buffer[15]
+            Velocity:  data20 data 21 or buffer[16] buffer [17]
         */
-        reading_m = UINT16_VALUE(buffer[17], buffer[18]) * 0.01;
+
+        reading_m = UINT16_VALUE(buffer[13], buffer[14]) * 0.01;
+
         const uint8_t snr = buffer[15];
 
+        /*
+        Set the data is available
+        */
         has_data = true;
 
-        if (malfunction_alert_prev != malfunction_alert) {
+        /*
+        Check for malfunction
+        */
+        if (malfunction_alert_prev != malfunction_alert)
+        {
             malfunction_alert_prev = malfunction_alert;
             report_malfunction(malfunction_alert);
         }
 
         /* From datasheet:
-            Altitude measurements associated with a SNR value 
-            of 13dB or lower are considered erroneous. 
+            Altitude measurements associated with a SNR value
+            of 13dB or lower are considered erroneous.
 
             SNR values of 0 are considered out of maximum range (655 metres)
 
             The altitude measurements should not in any circumstances be used as true
-            measurements independently of the corresponding SNR values. 
+            measurements independently of the corresponding SNR values.
         */
         signal_quality_pct = (snr <= 13 || malfunction_alert != 0) ? SIGNAL_QUALITY_MIN : SIGNAL_QUALITY_MAX;
 
-        if (snr <= 13) {            
-            has_data = false;           
-            if (snr == 0) {
+        if (snr <= 13)
+        {
+            has_data = false;
+            if (snr == 0)
+            {
                 state.status = RangeFinder::Status::OutOfRangeHigh;
                 reading_m = MAX(656, max_distance_cm() * 0.01 + 1);
-            } else {
+            }
+            else
+            {
                 state.status = RangeFinder::Status::NoData;
             }
-        } else {
+        }
+        else
+        {
             state.status = RangeFinder::Status::Good;
         }
     }
@@ -155,53 +188,70 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
     Reporting any warnings from the radar
 */
 
-void AP_RangeFinder_Ainstein_LRD1_Pro::report_malfunction(const uint16_t _malfunction_alert_) {
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature)) {
+void AP_RangeFinder_Ainstein_LRD1_Pro::report_malfunction(const uint16_t _malfunction_alert_)
+{
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: FPGA Temperature alert");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::FPGAVoltage)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::FPGAVoltage))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: FPGA Voltage Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_60G)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_60G))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 60G-SOC Temperature Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Voltage_60G)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Voltage_60G))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 60G-SOC Voltage Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_24G)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_24G))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 24G RF Temperature Warning");
-    }    
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::TransmitPower_24G)) {
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::TransmitPower_24G))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 24G RF Transmit Power Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::OverCurrent)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::OverCurrent))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Whole Board Overcurrent Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::IFSignalSaturation)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::IFSignalSaturation))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: IF Signal Saturation Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Software_24G)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Software_24G))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 24G Software Failure Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_60G)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_60G))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 60G Software Failure Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::AltitudeReading)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::AltitudeReading))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Altitude Reading Overflow Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::AttitudeAngle)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::AttitudeAngle))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Excessive Attitude Angle Warning");
-    }    
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::FrameError_60G)) {
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::FrameError_60G))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 60G Frame Error Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::InvalidAltitude)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::InvalidAltitude))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Invalid Altitude Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::InConAlttitude)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::InConAlttitude))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder:24G & 60G Altitude Inconsistency Warning");
     }
-    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::BoardVoltage)) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::BoardVoltage))
+    {
         GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Whole Board Voltage Warning");
     }
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -1,0 +1,209 @@
+/*
+   This program is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include "AP_RangeFinder_Ainstein_LRD1_Pro.h"
+
+#if AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED
+
+#include <GCS_MAVLink/GCS.h>
+
+// sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
+uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
+{
+    uint16_t ret = 0;
+    for (uint32_t i=0; i<count; i++) {
+        ret += data[i];
+    }
+    return ret;
+}
+
+// sums the bytes in the supplied buffer, returns that sum mod 256
+// (i.e. shoved into a uint8_t)
+uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count)
+{
+    return crc_sum_of_bytes_16(data, count) & 0xFF;
+}
+
+
+// get_reading - read a value from the sensor
+bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
+{
+    if (uart == nullptr || uart->available() == 0) {
+        return false;
+    }
+
+    bool has_data = false;
+
+    uint32_t available = MAX(uart->available(), static_cast<unsigned int>(PACKET_SIZE*4));
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Packet available :: %lu ", available);
+    while (available >= PACKET_SIZE) {
+        // ---------------
+        // Sync up with the header
+        const uint8_t header[] = {
+            0xEB,   // Header MSB
+            0x90,   // Header LSB
+            0x00   // Device ID
+        };
+        for (uint8_t i = 0; i<ARRAY_SIZE(header); i++) {
+            // available--;
+            while (uart->read() != header[i]) {
+                available--;
+                continue;
+            }
+        }
+
+        const uint8_t rest_of_packet_size = (PACKET_SIZE - ARRAY_SIZE(header));
+        if (available < rest_of_packet_size) {  
+            return false;
+        }
+
+        // 
+        // header is aligned!
+        // ---------------
+        
+        /*
+        This is reading from the uart and storing in the buffer
+        */ 
+        uint8_t buffer[rest_of_packet_size];
+        available -= uart->read(buffer, ARRAY_SIZE(buffer));
+
+        /*
+        Validating the : 
+        Checksum: (data4+data5+…+data30+data31) bitwise-AND
+        with 0xFF
+        */
+        const uint8_t checksum = buffer[ARRAY_SIZE(buffer)-1]; // last byte is a checksum
+        if (crc_sum_of_bytes(buffer, ARRAY_SIZE(buffer)-1) != checksum) {
+            // bad Checksum
+            continue;
+        }
+        
+        /*
+        This is alert for any malfunction set in data5 and data6
+        since buffer is starts from data 4 (header allign) so buffer[1] buffer[2]
+        0x0000: Normal
+        Others: Malfunction Alert
+        */
+        const uint8_t malfunction_alert = UINT16_VALUE(buffer[1], buffer[2]);
+
+        /*
+        Reading data packets:
+        24 Gz:
+        Altitude : data7 data8 or buffer[3] buffer[4]
+        SNR:       data9 or buffer[5]
+        Velocity:  data10 data 11 or buffer[6] buffer [7]
+        60 Gz :
+        Altitude : data12 data13 or buffer[8] buffer[9]
+        SNR:       data14 or buffer[10]
+        Velocity:  data15 data 16 or buffer[11] buffer [12]
+        Integrated:
+        Altitude : data17 data18 or buffer[13] buffer[14]
+        SNR:       data19 or buffer[15]
+        Velocity:  data20 data 21 or buffer[16] buffer [17]
+        */
+        reading_m = UINT16_VALUE(buffer[17], buffer[18]) * 0.01;
+        const uint8_t snr = buffer[15];
+
+        has_data = true;
+
+        if (malfunction_alert_prev != malfunction_alert) {
+            malfunction_alert_prev = malfunction_alert;
+            report_malfunction(malfunction_alert);
+        }
+
+        /* From datasheet:
+            Altitude measurements associated with a SNR value 
+            of 13dB or lower are considered erroneous. 
+
+            SNR values of 0 are considered out of maximum range (655 metres)
+
+            The altitude measurements should not in any circumstances be used as true
+            measurements independently of the corresponding SNR values. 
+        */
+        signal_quality_pct = (snr <= 13 || malfunction_alert != 0) ? SIGNAL_QUALITY_MIN : SIGNAL_QUALITY_MAX;
+
+        if (snr <= 13) {            
+            has_data = false;           
+            if (snr == 0) {
+                state.status = RangeFinder::Status::OutOfRangeHigh;
+                reading_m = MAX(656, max_distance_cm() * 0.01 + 1);
+            } else {
+                state.status = RangeFinder::Status::NoData;
+            }
+        } else {
+            state.status = RangeFinder::Status::Good;
+        }
+    }
+
+    return has_data;
+}
+
+/*
+    Reporting any warnings from the radar
+*/
+
+void AP_RangeFinder_Ainstein_LRD1_Pro::report_malfunction(const uint16_t _malfunction_alert_) {
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: FPGA Temperature alert");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::FPGAVoltage)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: FPGA Voltage Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_60G)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 60G-SOC Temperature Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Voltage_60G)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 60G-SOC Voltage Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_24G)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 24G RF Temperature Warning");
+    }    
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::TransmitPower_24G)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 24G RF Transmit Power Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::OverCurrent)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Whole Board Overcurrent Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::IFSignalSaturation)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: IF Signal Saturation Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Software_24G)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 24G Software Failure Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::Temperature_60G)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 60G Software Failure Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::AltitudeReading)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Altitude Reading Overflow Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::AttitudeAngle)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Excessive Attitude Angle Warning");
+    }    
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::FrameError_60G)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: 60G Frame Error Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::InvalidAltitude)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Invalid Altitude Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::InConAlttitude)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder:24G & 60G Altitude Inconsistency Warning");
+    }
+    if (_malfunction_alert_ & static_cast<uint16_t>(MalfunctionAlert::BoardVoltage)) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "RangeFinder: Whole Board Voltage Warning");
+    }
+}
+
+#endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -19,6 +19,8 @@
 
 #include <GCS_MAVLink/GCS.h>
 #include <ctype.h>
+#include <AP_Logger/AP_Logger.h>
+#include <AP_Vehicle/AP_Vehicle_Type.h>
 
 // sums the bytes in the supplied buffer, returns that sum mod 0xFFFF
 uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
@@ -54,11 +56,14 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
 
     bool has_data = false;
     int16_t nbytes = uart->available();
+    uint16_t reading_24Gz_cm, reading_60Gz_cm, reading_Int_cm;
+    uint8_t snr_24, snr_60, snr_Int;
+    
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Data Length:: %f", float(nbytes));
     while (nbytes-- > PACKET_SIZE)
     {
-        int16_t r = uart->read();
-        uint8_t c = (uint8_t)r;
+        // int16_t r = uart->read();
+        // uint8_t c = (uint8_t)r;
 
         const uint8_t header[] = {
             0xEB, // Header MSB
@@ -134,8 +139,14 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
         */
 
         reading_m = UINT16_VALUE(buffer[13], buffer[14]) * 0.01;
+        reading_24Gz_cm = UINT16_VALUE(buffer[3], buffer[4]);
+        reading_60Gz_cm = UINT16_VALUE(buffer[8], buffer[9]);
+        reading_Int_cm = UINT16_VALUE(buffer[13], buffer[14]);
 
         const uint8_t snr = buffer[15];
+        snr_24 = buffer[5];
+        snr_60 = buffer[10];
+        snr_Int = buffer[15];
 
         /*
         Set the data is available
@@ -181,8 +192,37 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
         }
     }
 
+    /*Logging Point Start*/
+    #if HAL_LOGGING_ENABLED
+        if(has_data){
+            Log_LRD1_Pro(reading_24Gz_cm, reading_60Gz_cm, reading_Int_cm, snr_24, snr_60, snr_Int);
+        }
+        
+    #endif 
+
     return has_data;
 }
+
+ /* Logging Function */
+ // Write an RFND (rangefinder) packet
+void AP_RangeFinder_Ainstein_LRD1_Pro::Log_LRD1_Pro(uint16_t s_24, uint16_t s_60, uint16_t s_int, uint8_t snr_24, uint8_t snr_60, uint8_t snr_int) const
+{
+
+    // AP_Logger &logger = AP::logger();
+
+    const struct log_LRD1 pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_LRD1_MSG),
+        time_us      : AP_HAL::micros64(),
+        dist_24_cm   : s_24 ,
+        dist_60_cm   : s_60,
+        dist_int_cm  : s_int,
+        snr_24       : snr_24,
+        snr_60       : snr_60,
+        snr_int      : snr_int,
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
 
 /*
     Reporting any warnings from the radar

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -44,18 +44,17 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
 {
     if (uart == nullptr)
     {
-        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Abhishek :: get_reading UART Connection NULL");
+        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Serial Connection LRD1 Pro is NULL");
     }
-    if (uart == nullptr || uart->available() == 0)
+    if (uart->available() == 0)
     {
-        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "Abhishek :: get_reading connection (%f)", float(uart->available()));
+        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "No Data from the LRD1Pro Radar (%f)", float(uart->available()));
         return false;
     }
 
     bool has_data = false;
     int16_t nbytes = uart->available();
 
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Data Length:: %f", float(nbytes));
     while (nbytes-- > PACKET_SIZE)
     {
         // int16_t r = uart->read();
@@ -141,7 +140,7 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
         /* Validate the Data */
 
         has_data = check_radar_reading(reading_m);
-        
+
         /*
         Check for malfunction
         */

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
@@ -7,7 +7,7 @@
  - bug on page 22 on malfunction codes
  - fixed length seems strange at 28 bytes
  - definition of snr field is missing in documentation
- - roll/pitch limits are in conflict, 3.2 vs 
+ - roll/pitch limits are in conflict, 3.2 vs
 */
 
 #include "AP_RangeFinder.h"
@@ -31,25 +31,25 @@ class AP_RangeFinder_Ainstein_LRD1_Pro : public AP_RangeFinder_Backend_Serial
 {
 
 public:
-
     static AP_RangeFinder_Backend_Serial *create(
         RangeFinder::RangeFinder_State &_state,
-        AP_RangeFinder_Params &_params) {
+        AP_RangeFinder_Params &_params)
+    {
         return new AP_RangeFinder_Ainstein_LRD1_Pro(_state, _params);
     }
 
 protected:
-
-    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override
+    {
         return MAV_DISTANCE_SENSOR_RADAR;
     }
 
-    uint32_t initial_baudrate(uint8_t serial_instance) const override {
+    uint32_t initial_baudrate(uint8_t serial_instance) const override
+    {
         return 115200;
     }
 
 private:
-
     using AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial;
 
     // get a reading
@@ -58,30 +58,32 @@ private:
     // 0 is no return value, 100 is perfect.  false means signal
     // quality is not available
     // int8_t get_signal_quality_pct() const override { return signal_quality_pct; };
-    bool get_signal_quality_pct(uint8_t &quality_pct) const override {
+    bool get_signal_quality_pct(uint8_t &quality_pct) const override
+    {
         quality_pct = no_signal ? 0 : 100;
         return true;
     }
 
     static void report_malfunction(const uint16_t _malfunction_alert_);
 
-    enum class MalfunctionAlert : uint16_t {
-        Temperature        = (1U << 0),  // 0x0001
-        FPGAVoltage        = (1U << 1),  // 0x0002
-        Temperature_60G    = (1U << 2),  // 0x0004
-        Voltage_60G        = (1U << 3),  // 0x0008
-        Temperature_24G    = (1U << 4),  // 0x0010
-        TransmitPower_24G  = (1U << 5),  // 0x0020
-        OverCurrent        = (1U << 6),  // 0x0040 
-        IFSignalSaturation = (1U << 7),  // 0x0080
-        Software_24G       = (1U << 8),  // 0x0100
-        Software_60G       = (1U << 9),  // 0x0200
-        AltitudeReading    = (1U << 10),  // 0x0400
-        AttitudeAngle      = (1U << 11),  // 0x0800
-        FrameError_60G     = (1U << 12),  // 0x1000
-        InvalidAltitude    = (1U << 13),  // 0x2000
-        InConAlttitude     = (1U << 14),  // 0x4000
-        BoardVoltage       = (1U << 15),  // 0x8000
+    enum class MalfunctionAlert : uint16_t
+    {
+        Temperature = (1U << 0),        // 0x0001
+        FPGAVoltage = (1U << 1),        // 0x0002
+        Temperature_60G = (1U << 2),    // 0x0004
+        Voltage_60G = (1U << 3),        // 0x0008
+        Temperature_24G = (1U << 4),    // 0x0010
+        TransmitPower_24G = (1U << 5),  // 0x0020
+        OverCurrent = (1U << 6),        // 0x0040
+        IFSignalSaturation = (1U << 7), // 0x0080
+        Software_24G = (1U << 8),       // 0x0100
+        Software_60G = (1U << 9),       // 0x0200
+        AltitudeReading = (1U << 10),   // 0x0400
+        AttitudeAngle = (1U << 11),     // 0x0800
+        FrameError_60G = (1U << 12),    // 0x1000
+        InvalidAltitude = (1U << 13),   // 0x2000
+        InConAlttitude = (1U << 14),    // 0x4000
+        BoardVoltage = (1U << 15),      // 0x8000
     };
 
     static constexpr uint8_t PACKET_SIZE = 32;
@@ -89,7 +91,7 @@ private:
     bool no_signal = false;
     int8_t signal_quality_pct = SIGNAL_QUALITY_UNKNOWN;
 
-    // Logging Function
-    void Log_LRD1_Pro(uint16_t s_24, uint16_t s_60, uint16_t s_int, uint8_t snr_24, uint8_t snr_60, uint8_t snr_int) const;
+    // Validating if the reading is good
+    bool check_radar_reading(float &reading_m);
 };
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
@@ -87,6 +87,9 @@ private:
     static constexpr uint8_t PACKET_SIZE = 32;
     uint8_t malfunction_alert_prev;
     bool no_signal = false;
-    int8_t signal_quality_pct = SIGNAL_QUALITY_UNKNOWN;    
+    int8_t signal_quality_pct = SIGNAL_QUALITY_UNKNOWN;
+
+    // Logging Function
+    void Log_LRD1_Pro(uint16_t s_24, uint16_t s_60, uint16_t s_int, uint8_t snr_24, uint8_t snr_60, uint8_t snr_int) const;
 };
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
@@ -1,0 +1,92 @@
+#pragma once
+
+// #include "AP_RangeFinder_config.h"
+
+/*
+ questions:
+ - bug on page 22 on malfunction codes
+ - fixed length seems strange at 28 bytes
+ - definition of snr field is missing in documentation
+ - roll/pitch limits are in conflict, 3.2 vs 
+*/
+
+#include "AP_RangeFinder.h"
+#include "AP_RangeFinder_Backend_Serial.h"
+
+#ifndef AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED
+#define AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED AP_RANGEFINDER_BACKEND_DEFAULT_ENABLED
+#endif
+#if AP_RANGEFINDER_AINSTEIN_LRD1_PRO_SERIAL_ENABLED
+
+// #include "AP_Math/crc.h"
+
+static constexpr int8_t SIGNAL_QUALITY_MIN = 0;
+static constexpr int8_t SIGNAL_QUALITY_MAX = 100;
+static constexpr int8_t SIGNAL_QUALITY_UNKNOWN = -1;
+
+uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count);
+uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count);
+
+class AP_RangeFinder_Ainstein_LRD1_Pro : public AP_RangeFinder_Backend_Serial
+{
+
+public:
+
+    static AP_RangeFinder_Backend_Serial *create(
+        RangeFinder::RangeFinder_State &_state,
+        AP_RangeFinder_Params &_params) {
+        return new AP_RangeFinder_Ainstein_LRD1_Pro(_state, _params);
+    }
+
+protected:
+
+    MAV_DISTANCE_SENSOR _get_mav_distance_sensor_type() const override {
+        return MAV_DISTANCE_SENSOR_RADAR;
+    }
+
+    uint32_t initial_baudrate(uint8_t serial_instance) const override {
+        return 115200;
+    }
+
+private:
+
+    using AP_RangeFinder_Backend_Serial::AP_RangeFinder_Backend_Serial;
+
+    // get a reading
+    bool get_reading(float &reading_m) override;
+
+    // 0 is no return value, 100 is perfect.  false means signal
+    // quality is not available
+    // int8_t get_signal_quality_pct() const override { return signal_quality_pct; };
+    bool get_signal_quality_pct(uint8_t &quality_pct) const override {
+        quality_pct = no_signal ? 0 : 100;
+        return true;
+    }
+
+    static void report_malfunction(const uint16_t _malfunction_alert_);
+
+    enum class MalfunctionAlert : uint16_t {
+        Temperature        = (1U << 0),  // 0x0001
+        FPGAVoltage        = (1U << 1),  // 0x0002
+        Temperature_60G    = (1U << 2),  // 0x0004
+        Voltage_60G        = (1U << 3),  // 0x0008
+        Temperature_24G    = (1U << 4),  // 0x0010
+        TransmitPower_24G  = (1U << 5),  // 0x0020
+        OverCurrent        = (1U << 6),  // 0x0040 
+        IFSignalSaturation = (1U << 7),  // 0x0080
+        Software_24G       = (1U << 8),  // 0x0100
+        Software_60G       = (1U << 9),  // 0x0200
+        AltitudeReading    = (1U << 10),  // 0x0400
+        AttitudeAngle      = (1U << 11),  // 0x0800
+        FrameError_60G     = (1U << 12),  // 0x1000
+        InvalidAltitude    = (1U << 13),  // 0x2000
+        InConAlttitude     = (1U << 14),  // 0x4000
+        BoardVoltage       = (1U << 15),  // 0x8000
+    };
+
+    static constexpr uint8_t PACKET_SIZE = 32;
+    uint8_t malfunction_alert_prev;
+    bool no_signal = false;
+    int8_t signal_quality_pct = SIGNAL_QUALITY_UNKNOWN;    
+};
+#endif


### PR DESCRIPTION
This repo consists of the driver for TTL communication with the LRD1 Pro Radar.

Documents:
- [LRD1 Pro Manual](https://malloyaeronautics2022-my.sharepoint.com/:b:/r/personal/abhishek_saxena_malloyaeronautics_com/Documents/Documents/Projects_malloy/LR-D1-Radar%20Driver/LR-D1%20Pro%20Technical%20User%20Manual%20V1.9.docx.pdf?csf=1&web=1&e=U1bS2F)
- [LRD1 Pro Analysis](https://malloyaeronautics2022-my.sharepoint.com/:w:/r/personal/abhishek_saxena_malloyaeronautics_com/Documents/Documents/Projects_malloy/LR-D1-Radar%20Driver/LRD1%20Pro%20Analysis.docx?d=w6b2220dd139b4e958d72c44badef0f78&csf=1&web=1&e=QNZEFB)

Now Structure of the Code:
**RangeFinder.h**:
Declares the new parameter for the Radar: Ainstein_LRD1_Pro

**RangeFinder.cpp**:
Based on the selected parameter "Ainstein_LRD1_Pro" calls the driver: 
serial_create_fn = AP_RangeFinder_Ainstein_LRD1_Pro::create

**AP_RangeFinder_Ainstein_LRD1_Pro.h** the header file:

- After the serial connection is made the data is generated from "get_reading" function.
- I have also declared malfunction params in enum class "MalfunctionAlert"

**AP_RangeFinder_Ainstein_LRD1_Pro.cpp** :
Definitions of all functions in the class AP_RangeFinder_Ainstein_LRD1_Pro are here.
**get reading** function:
- Checks for the serial connection and available data.
- If number of bytes > 32 (Total packet length from the radar), we will process the information. On bench setup, I observed each packet length is 96 or 128 bytes.
- If there is enough data we sync the header. Meaning the first 3 bytes from the packet are matched to pre-known header values as mentioned in the documents above.
- Then we take the next 28 bytes of data to take out the value of the Integrated signal which is byte (13, 14) from the buffer.
- We check for the range and signal to noise ratio and return the status message back to the front end.

