### PR TITLE
[NHW] Removed status text lines on trival warning case.

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -45,11 +45,10 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
 {
     if (uart == nullptr)
     {
-        GCS_SEND_TEXT(MAV_SEVERITY_CRITICAL, "Serial Connection LRD1 Pro is NULL");
+        return false;
     }
     if (uart->available() == 0)
     {
-        GCS_SEND_TEXT(MAV_SEVERITY_ERROR, "No Data from the LRD1Pro Radar (%f)", float(uart->available()));
         return false;
     }
 


### PR DESCRIPTION
The status text lines removed create a warning message spam to the GCS in the event that the rangefinder is not connected. 

The update has the attempted read function simply exit if a read attempt is made and there is no data available. 