### PR TITLE
Fix min value lrd1

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -230,11 +230,6 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::check_radar_reading(float &reading_m)
         reading_m = MIN(656, reading_m);
         return false;
     }
-    // We want to provide the reading for lower value
-    if(reading_m < 0.3)
-    {
-        reading_m = 0.3; 
-    }
     return true;
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -157,7 +157,8 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
         if (malfunction_alert_prev != malfunction_alert)
         {
             malfunction_alert_prev = malfunction_alert;
-            report_malfunction(malfunction_alert);
+            // The report malfunction is for debug use only
+            // report_malfunction(malfunction_alert);
         }
 
         /* From datasheet:

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -224,11 +224,15 @@ void AP_RangeFinder_Ainstein_LRD1_Pro::Log_LRD1_Pro(
 bool AP_RangeFinder_Ainstein_LRD1_Pro::check_radar_reading(float &reading_m)
 {
     // Range of the LRD1 Pro 0.3m to 656m
-    if (reading_m < 0.3 || reading_m > 655)
+    if (reading_m > 655)
     {
         reading_m = MIN(656, reading_m);
-        reading_m = MAX(0.3, reading_m);
         return false;
+    }
+    // We want to provide the reading for lower value
+    if(reading_m < 0.3)
+    {
+        reading_m = 0.3; 
     }
     return true;
 }


### PR DESCRIPTION
The issue:
If the LRD1 is <0.3m above ground it will send no data for rangefinder.
The timeout for the no data in the code base is defined in `AP_RangeFinder_Backend_Serial.cpp` function `void AP_RangeFinder_Backend_Serial::update(void)`

`} else if (AP_HAL::millis() - state.last_reading_ms > read_timeout_ms()) {
        set_status(RangeFinder::Status::NoData);
    }`
Where time out is **200ms**

Solution :
I have set if the value <0.3m then it is limited to 0.3
@NickWilsonMA Please let me know if you want to make this value as 0.

Secondly I've commented on the function to report malfunction as it spam the messages at 20 Hz

Please check the changes for your reference.

Validation:
Tested the driver on the bench.

