### PR TITLE
Lrd1 24 int signal param

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -29,7 +29,6 @@ uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
     {
         ret += data[i];
     }
-    // 
     return ret;
 }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -29,7 +29,7 @@ uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count)
     {
         ret += data[i];
     }
-    // GCS_SEND_TEXT(MAV_SEVERITY_ERROR,"Abhishek :: CheckSum :: (%f)", float(ret));
+    // 
     return ret;
 }
 
@@ -61,9 +61,7 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
 
     while (nbytes-- > PACKET_SIZE)
     {
-        // int16_t r = uart->read();
-        // uint8_t c = (uint8_t)r;
-
+        // Syncing the Header to the start of the Packet
         const uint8_t header[] = {
             0xEB, // Header MSB
             0x90, // Header LSB
@@ -136,8 +134,20 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
             SNR:       data19 or buffer[15]
             Velocity:  data20 data 21 or buffer[16] buffer [17]
         */
-        reading_m = UINT16_VALUE(buffer[13], buffer[14]) * 0.01;
-        const uint8_t snr = buffer[15];
+
+        uint8_t snr = 0;
+        /*
+            Param: RNGFND1_LRD1MOD will give value:
+            0: 24GHz Mode (Default) and 1: Integrated Mode
+        */
+        if (lrd1_freq_mode() == 1){
+            reading_m = UINT16_VALUE(buffer[13], buffer[14]) * 0.01;
+            snr = buffer[15];
+        }
+        else{
+            reading_m = UINT16_VALUE(buffer[3], buffer[4]) * 0.01;
+            snr = buffer[5];
+        }
 
         /* Setting Logging Params */
         reading_24Gz_cm = UINT16_VALUE(buffer[3], buffer[4]);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -45,6 +45,7 @@ public:
     virtual int16_t max_distance_cm() const { return params.max_distance_cm; }
     virtual int16_t min_distance_cm() const { return params.min_distance_cm; }
     int16_t ground_clearance_cm() const { return params.ground_clearance_cm; }
+    int8_t lrd1_freq_mode() const { return params.lrd1_freq_mode; }
     MAV_DISTANCE_SENSOR get_mav_distance_sensor_type() const;
     RangeFinder::Status status() const;
     RangeFinder::Type type() const { return (RangeFinder::Type)params.type.get(); }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -138,6 +138,13 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("ORIENT", 53, AP_RangeFinder_Params, orientation, AP_RANGEFINDER_DEFAULT_ORIENTATION),
 
+    // @Param: LRD1MODE
+    // @DisplayName: LRD1 Ops Mode
+    // @Description: LRD1 Frequency Mode: 24GHz or Integrated
+    // @Values: 0:24GHz,1:Int-Signal
+    // @User: Standard
+    AP_GROUPINFO("LRD1MODE", 54, AP_RangeFinder_Params, lrd1_freq_mode, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -27,4 +27,6 @@ public:
     AP_Int8  ground_clearance_cm;
     AP_Int8  address;
     AP_Int8  orientation;
+    // LRD1 frequency mode (24GHz of Integrated)
+    AP_Int8  lrd1_freq_mode;
 };


### PR DESCRIPTION
**Issue:**
60GHz signal interfering at ~20meters giving faulty values.

**Solution:**
Restricting to the use of 24GHz signal for height and setting the minimum height for the use of the Radar to 8m
 Also, I have created a param **RNGFND1_LRD1MODE** that has 2 values:
 0: for 24 Ghz signal
1: for integrated signal that will have 60GHz signal <8meters and 24GHz signal >8meters
   