### PR TITLE
Filtering data from the integrated signal of LRD1

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -170,7 +170,9 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
         {
             malfunction_alert_prev = malfunction_alert;
             // The report malfunction is for debug use only
-            // report_malfunction(malfunction_alert);
+            if(lrd1_logs() == 1){
+                report_malfunction(malfunction_alert);
+            }
         }
 
         /* From datasheet:

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -51,6 +51,9 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
         return false;
     }
 
+    // Noting the current sensor value
+    float current_dist_reading_m = reading_m;
+
     bool has_data = false;
     int16_t nbytes = uart->available();
 
@@ -193,6 +196,13 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
             {
                 state.status = RangeFinder::Status::NoData;
             }
+        }
+        /* Adding a check to ignore sudden jumps in height from Radar*/
+        else if(state.status == RangeFinder::Status::Good && 
+                (reading_m - current_dist_reading_m > CHANGE_HEIGHT_THRESHOLD ||
+                reading_m - current_dist_reading_m < -CHANGE_HEIGHT_THRESHOLD)){
+            state.status = RangeFinder::Status::NoData;
+            has_data = false;
         }
         else
         {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
@@ -23,6 +23,7 @@
 static constexpr int8_t SIGNAL_QUALITY_MIN = 0;
 static constexpr int8_t SIGNAL_QUALITY_MAX = 100;
 static constexpr int8_t SIGNAL_QUALITY_UNKNOWN = -1;
+static constexpr int8_t CHANGE_HEIGHT_THRESHOLD = 5;
 
 uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count);
 uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -46,6 +46,7 @@ public:
     virtual int16_t min_distance_cm() const { return params.min_distance_cm; }
     int16_t ground_clearance_cm() const { return params.ground_clearance_cm; }
     int8_t lrd1_freq_mode() const { return params.lrd1_freq_mode; }
+    int8_t lrd1_logs() const { return params.lrd1_logs; }
     MAV_DISTANCE_SENSOR get_mav_distance_sensor_type() const;
     RangeFinder::Status status() const;
     RangeFinder::Type type() const { return (RangeFinder::Type)params.type.get(); }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -143,7 +143,7 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @Description: LRD1 Frequency Mode: 24GHz or Integrated
     // @Values: 0:24GHz,1:Int-Signal
     // @User: Standard
-    AP_GROUPINFO("LRD1MODE", 54, AP_RangeFinder_Params, lrd1_freq_mode, 0),
+    AP_GROUPINFO("LRD1MODE", 54, AP_RangeFinder_Params, lrd1_freq_mode, 1),
 
     // @Param: LRD1LOG
     // @DisplayName: LRD1 Logs Enabled

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -145,6 +145,13 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("LRD1MODE", 54, AP_RangeFinder_Params, lrd1_freq_mode, 0),
 
+    // @Param: LRD1LOG
+    // @DisplayName: LRD1 Logs Enabled
+    // @Description: Enable debug logs for LRD1
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Standard
+    AP_GROUPINFO("LRD1LOG", 55, AP_RangeFinder_Params, lrd1_logs, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -29,4 +29,6 @@ public:
     AP_Int8  orientation;
     // LRD1 frequency mode (24GHz of Integrated)
     AP_Int8  lrd1_freq_mode;
+    // LRD1 Debug Log
+    AP_Int8  lrd1_logs;
 };


### PR DESCRIPTION
Issue:
On testing Version MA-Copter-4.3.0.6 we observed that the 24GHZ signal distance is noisy (>5m of fluctuations).
![image](https://github.com/user-attachments/assets/2d9be370-0ba0-4b6d-827d-a6654e87913e)

We also observed drops in height when testing the Integrated signal:
![image](https://github.com/user-attachments/assets/c4e810ff-8d0b-4b41-bae0-a50216407d62)

Logs Location: _Malloy Aeronautics\Malloy Aero Home - Documents\TRV150\Flight Logs\2024\20241021 T150B 044 LRD1 Radar Altemeter Test Logs_

So for this, I have proposed the following change.
**Suggestion1:** We will use the Integrated signal distance from the LRD1.
**Sol for the sudden drops:**
We are currently getting data at 20 Hz from the sensor. I will ignore the data which compared to previous good data is greater than threshold (CHANGE_HEIGHT_THRESHOLD set to 5m).
The reason: for distance to change by 5 meters over a 50ms time period (20 Hz) your speed needs to be 100m/sec or 360km/hr

Secondly, I have added a param for reporting the malfunction from the radar. This will help debug if needed. 