### PR TITLE
Lrd1 moving avg lpf

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -205,6 +205,7 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
         }
         else
         {
+            reading_m = get_avg_reading(reading_m);
             state.status = RangeFinder::Status::Good;
         }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
@@ -23,6 +23,7 @@
 static constexpr int8_t SIGNAL_QUALITY_MIN = 0;
 static constexpr int8_t SIGNAL_QUALITY_MAX = 100;
 static constexpr int8_t SIGNAL_QUALITY_UNKNOWN = -1;
+static constexpr int8_t CHANGE_HEIGHT_THRESHOLD = 5;
 
 uint16_t crc_sum_of_bytes_16(const uint8_t *data, uint16_t count);
 uint8_t crc_sum_of_bytes(const uint8_t *data, uint16_t count);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.cpp
@@ -80,3 +80,21 @@ void AP_RangeFinder_Backend::set_status(RangeFinder::Status _status)
     }
 }
 
+// Function to be called to update reading and calculate average
+float AP_RangeFinder_Backend::get_avg_reading(float new_reading) {
+    // Add new reading to the circular buffer
+    int8_t _window_size = lrd1_lpf_window();
+    int8_t _cur_window_pos = get_lrd1_cur_pos();
+    params._range_window[_cur_window_pos % _window_size] = new_reading;
+    _cur_window_pos++;
+    if (_cur_window_pos >= _window_size){
+        _cur_window_pos =0;
+    }
+    // Calculate the average of active elements in the buffer
+    float sum = 0.0f;
+    for (int i = 0; i < _window_size; ++i) {
+        sum += params._range_window[i];
+    }
+    set_lrd1_cur_pos(_cur_window_pos);
+    return sum / _window_size;
+}

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -52,23 +52,7 @@ public:
     int8_t get_lrd1_cur_pos(){ return params.lrd1_cur_pos; }
 
     // Function to be called to update reading and calculate average
-    float get_avg_reading(float new_reading) {
-        // Add new reading to the circular buffer
-        int8_t _window_size = lrd1_lpf_window();
-        int8_t _cur_window_pos = get_lrd1_cur_pos();
-        params._range_window[_cur_window_pos % _window_size] = new_reading;
-        _cur_window_pos++;
-        if (_cur_window_pos >= _window_size){
-            _cur_window_pos =0;
-        }
-        // Calculate the average of active elements in the buffer
-        float sum = 0.0f;
-        for (int i = 0; i < _window_size; ++i) {
-            sum += params._range_window[i];
-        }
-        set_lrd1_cur_pos(_cur_window_pos);
-        return sum / _window_size;
-    }
+    float get_avg_reading(float new_reading);
 
     MAV_DISTANCE_SENSOR get_mav_distance_sensor_type() const;
     RangeFinder::Status status() const;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -65,10 +65,7 @@ public:
         float sum = 0.0f;
         for (int i = 0; i < _window_size; ++i) {
             sum += params._range_window[i];
-            GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RangeFinder Val [%d]: %.1f", i, params._range_window[i]);
         }
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "-----------------------");
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "RangeFinder Avg Val: %.3f", (sum / _window_size));
         set_lrd1_cur_pos(_cur_window_pos);
         return sum / _window_size;
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -18,6 +18,7 @@
 #include <AP_HAL/AP_HAL_Boards.h>
 #include <AP_HAL/Semaphores.h>
 #include "AP_RangeFinder.h"
+#include <GCS_MAVLink/GCS.h>
 
 class AP_RangeFinder_Backend
 {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -145,6 +145,14 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("LRD1MODE", 54, AP_RangeFinder_Params, lrd1_freq_mode, 0),
 
+    // @Param: LRD1WND
+    // @DisplayName: LRD1 LPF Window 
+    // @Description:  LRD1 Moving average Low pass filter Window 
+    // @Range: 1 20
+    // @Increment: 1
+    // @User: Standard
+    AP_GROUPINFO("LRD1WND", 55, AP_RangeFinder_Params, lrd1_lpf_window, 5),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -3,6 +3,8 @@
 #include <AP_Param/AP_Param.h>
 #include <AP_Math/AP_Math.h>
 
+#define MAX_WINDOW_SIZE 20
+
 class AP_RangeFinder_Params {
 public:
     static const struct AP_Param::GroupInfo var_info[];
@@ -29,4 +31,8 @@ public:
     AP_Int8  orientation;
     // LRD1 frequency mode (24GHz of Integrated)
     AP_Int8  lrd1_freq_mode;
+    // LRD1 Low pass filter window size (1-20)
+    AP_Int8  lrd1_lpf_window;
+    int8_t lrd1_cur_pos;
+    float _range_window[MAX_WINDOW_SIZE];  // Static array for readings
 };


### PR DESCRIPTION
Issue:
On testing Version MA-Copter-4.3.0.6 we observed that the 24GHZ signal distance is noisy (>5m of fluctuations).
image
![image](https://github.com/user-attachments/assets/8338acd1-28ce-444d-bc8d-590790725480)

We also observed drops in height when testing the Integrated signal:
![image](https://github.com/user-attachments/assets/96208005-2dde-4485-8bbe-b7f2db8e6e09)


Logs Location: Malloy Aeronautics\Malloy Aero Home - Documents\TRV150\Flight Logs\2024\20241021 T150B 044 LRD1 Radar Altemeter Test Logs

So for this, I have proposed the following change.
Suggestion1: We will use the Integrated signal distance from the LRD1.
Sol for the sudden drops:
We are currently getting data at 20 Hz from the sensor. I will ignore the data which compared to previous good data is greater than threshold (CHANGE_HEIGHT_THRESHOLD set to 5m).
The reason: for distance to change by 5 meters over a 50ms time period (20 Hz) your speed needs to be 100m/sec or 360km/hr

Also as suggested by @NickWilsonMA I have also added a moving window low pass filter for the readings and added the values to the params class
