### PR TITLE
Fix lrd1 lpf driver

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -7,7 +7,7 @@
 #include "ap_version.h"
 
 
-#define THISFIRMWARE "MA V4.3.0.7"
+#define THISFIRMWARE "MA V4.3.0.8"
 
 
 // the following line is parsed by the autotest scripts

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -470,6 +470,7 @@ struct PACKED log_LRD1
   uint16_t dist_24_cm;  // Distance from 24GHz Freq (>5m)
   uint16_t dist_60_cm;  // Distance from 60GHz Freq (<5m)
   uint16_t dist_int_cm; // Distance from integrating 24 and 60 Ghz
+  uint16_t dist_lpf_cm; // Distance Distance reported after low pass filter
   uint8_t snr_24;       // Signal to Noise Ratio 24 Ghz
   uint8_t snr_60;       // Signal to Noise Ratio 60 Ghz
   uint8_t snr_int;      // Signal to Noise Ratio Integrated signal
@@ -1269,7 +1270,7 @@ LOG_STRUCTURE_FROM_CAMERA \
     { LOG_RFND_MSG, sizeof(log_RFND), \
       "RFND", "QBCBB", "TimeUS,Instance,Dist,Stat,Orient", "s#m--", "F-B--", true }, \
     { LOG_LRD1_MSG, sizeof(log_LRD1), \
-      "LRD1", "QCCCBBB", "TimeUS,Dis24,Dis60,DisInt,Snr24,Snr60,SnrInt", "smmm---", "FBBB---", true }, \
+      "LRD1", "QCCCCBBB", "TimeUS,Dis24,Dis60,DisInt,DisLpf,Snr24,Snr60,SnrInt", "smmm---", "FBBB---", true }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
       "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     LOG_STRUCTURE_FROM_BEACON                                       \

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1270,7 +1270,7 @@ LOG_STRUCTURE_FROM_CAMERA \
     { LOG_RFND_MSG, sizeof(log_RFND), \
       "RFND", "QBCBB", "TimeUS,Instance,Dist,Stat,Orient", "s#m--", "F-B--", true }, \
     { LOG_LRD1_MSG, sizeof(log_LRD1), \
-      "LRD1", "QCCCCBBB", "TimeUS,Dis24,Dis60,DisInt,DisLpf,Snr24,Snr60,SnrInt", "smmm---", "FBBB---", true }, \
+      "LRD1", "QCCCCBBB", "TimeUS,Dis24,Dis60,DisInt,DisLpf,Snr24,Snr60,SnrInt", "smmmm---", "FHHHH---", true }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
       "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     LOG_STRUCTURE_FROM_BEACON                                       \

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -191,20 +191,20 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
                 state.status = RangeFinder::Status::OutOfRangeHigh;
                 reading_m = MAX(656, max_distance_cm() * 0.01 + 1);
             }
-            /* Adding a check to ignore sudden jumps in height from Radar*/
-            else if(state.status == RangeFinder::Status::Good && 
-                   (reading_m - current_dist_reading_m > CHANGE_HEIGHT_THRESHOLD ||
-                   reading_m - current_dist_reading_m < -CHANGE_HEIGHT_THRESHOLD)){
-            state.status = RangeFinder::Status::NoData;
-            has_data = false;
-        }
             else
             {
                 state.status = RangeFinder::Status::NoData;
             }
         }
-        else
-        {
+            /* Adding a check to ignore sudden jumps in height from Radar*/
+        else if (state.status == RangeFinder::Status::Good &&
+                   (reading_m - current_dist_reading_m > CHANGE_HEIGHT_THRESHOLD ||
+                 reading_m - current_dist_reading_m < -CHANGE_HEIGHT_THRESHOLD)) {
+            state.status = RangeFinder::Status::NoData;
+            has_data = false;
+        }
+            else
+            {
             reading_m = get_avg_reading(reading_m);
             state.status = RangeFinder::Status::Good;
         }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -57,7 +57,7 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
     int16_t nbytes = uart->available();
 
     /* Adding the parameters to log the data */
-    uint16_t reading_24Gz_cm, reading_60Gz_cm, reading_Int_cm;
+    uint16_t reading_24Gz_cm, reading_60Gz_cm, reading_Int_cm, reading_lpf_cm;
     uint8_t snr_24, snr_60, snr_Int;
 
     while (nbytes-- > PACKET_SIZE)
@@ -207,13 +207,14 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
             {
             reading_m = get_avg_reading(reading_m);
             state.status = RangeFinder::Status::Good;
+            reading_lpf_cm = reading_m;
         }
 
         /* Logging Point Start */
 #if HAL_LOGGING_ENABLED
         if (has_data)
         {
-            Log_LRD1_Pro(reading_24Gz_cm, reading_60Gz_cm, reading_Int_cm, snr_24, snr_60, snr_Int);
+            Log_LRD1_Pro(reading_24Gz_cm, reading_60Gz_cm, reading_Int_cm, reading_lpf_cm, snr_24, snr_60, snr_Int);
         }
 #endif
     }
@@ -225,7 +226,7 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
     Write rangefinder packet for logging
 */
 void AP_RangeFinder_Ainstein_LRD1_Pro::Log_LRD1_Pro(
-    uint16_t s_24, uint16_t s_60, uint16_t s_int,
+    uint16_t s_24, uint16_t s_60, uint16_t s_int, uint16_t s_lpf,
     uint8_t snr_24, uint8_t snr_60, uint8_t snr_int) const
 {
     const struct log_LRD1 pkt = {
@@ -234,6 +235,7 @@ void AP_RangeFinder_Ainstein_LRD1_Pro::Log_LRD1_Pro(
         dist_24_cm : s_24,
         dist_60_cm : s_60,
         dist_int_cm : s_int,
+        dist_lpf_cm : s_lpf,
         snr_24 : snr_24,
         snr_60 : snr_60,
         snr_int : snr_int,

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.cpp
@@ -196,18 +196,18 @@ bool AP_RangeFinder_Ainstein_LRD1_Pro::get_reading(float &reading_m)
                 state.status = RangeFinder::Status::NoData;
             }
         }
-            /* Adding a check to ignore sudden jumps in height from Radar*/
+        /* Adding a check to ignore sudden jumps in height from Radar*/
         else if (state.status == RangeFinder::Status::Good &&
-                   (reading_m - current_dist_reading_m > CHANGE_HEIGHT_THRESHOLD ||
+                (reading_m - current_dist_reading_m > CHANGE_HEIGHT_THRESHOLD ||
                  reading_m - current_dist_reading_m < -CHANGE_HEIGHT_THRESHOLD)) {
             state.status = RangeFinder::Status::NoData;
             has_data = false;
         }
-            else
-            {
+        else
+        {
             reading_m = get_avg_reading(reading_m);
             state.status = RangeFinder::Status::Good;
-            reading_lpf_cm = reading_m;
+            reading_lpf_cm = reading_m*100;
         }
 
         /* Logging Point Start */

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Ainstein_LRD1_Pro.h
@@ -93,7 +93,7 @@ private:
     int8_t signal_quality_pct = SIGNAL_QUALITY_UNKNOWN;
 
     // Logging Function
-    void Log_LRD1_Pro(uint16_t s_24, uint16_t s_60, uint16_t s_int, uint8_t snr_24, uint8_t snr_60, uint8_t snr_int) const;
+    void Log_LRD1_Pro(uint16_t s_24, uint16_t s_60, uint16_t s_int, uint16_t s_lpf, uint8_t snr_24, uint8_t snr_60, uint8_t snr_int) const;
 
     // Validating if the reading is good
     bool check_radar_reading(float &reading_m);


### PR DESCRIPTION
This is to make the following fix to the driver post-testing:

- The threshold for removing the drop in the altitude for integrated signal persist
- Logging the new LPF data so that we can see the output after refining the data from the LRD1

![image](https://github.com/user-attachments/assets/17e606cd-4d69-4da0-8aae-2b1cdb37435c)

