### PR TITLE
Ukr stop pos logging

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -7,7 +7,7 @@
 #include "ap_version.h"
 
 
-#define THISFIRMWARE "MA V4.3.0.8"
+#define THISFIRMWARE "MA V4.3.0.8-DEV"
 
 
 // the following line is parsed by the autotest scripts

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -178,6 +178,13 @@ const AP_Param::GroupInfo AP_AHRS::var_info[] = {
 
     // index 17
 
+    // @Param: POS_LOG
+    // @DisplayName: Store the position in the logs in POS and AHRS
+    // @Description: This controls if we want to store the position in the logs in POS and AHRS messages.
+    // @Values: 0:Disabled,1:Enabled
+    // @User: Advanced
+    AP_GROUPINFO("POS_LOG",  17, AP_AHRS, _pos_logging, 0),
+
     AP_GROUPEND
 };
 
@@ -3145,9 +3152,10 @@ void AP_AHRS::Log_Write()
 #if HAL_NAVEKF3_AVAILABLE
     EKF3.Log_Write();
 #endif
-
-    Write_AHRS2();
-    Write_POS();
+    if (get_pos_logging_status() == 1){
+        Write_AHRS2();
+        Write_POS();
+    }
 
 #if AP_AHRS_SIM_ENABLED
     AP::sitl()->Log_Write_SIMSTATE();

--- a/libraries/AP_AHRS/AP_AHRS.cpp
+++ b/libraries/AP_AHRS/AP_AHRS.cpp
@@ -3152,10 +3152,9 @@ void AP_AHRS::Log_Write()
 #if HAL_NAVEKF3_AVAILABLE
     EKF3.Log_Write();
 #endif
-    if (get_pos_logging_status() == 1){
-        Write_AHRS2();
-        Write_POS();
-    }
+
+    Write_AHRS2();
+    Write_POS();
 
 #if AP_AHRS_SIM_ENABLED
     AP::sitl()->Log_Write_SIMSTATE();

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -612,8 +612,8 @@ public:
     const EKFGSF_yaw *get_yaw_estimator(void) const;
 
     // Return the param for status to record Position
-    int8_t get_pos_logging_status(void) {
-        return _pos_logging;
+    bool get_pos_logging_status(void) const {
+        return (_pos_logging !=0 )? true : false;
     }
 
 private:

--- a/libraries/AP_AHRS/AP_AHRS.h
+++ b/libraries/AP_AHRS/AP_AHRS.h
@@ -611,6 +611,11 @@ public:
     // get access to an EKFGSF_yaw estimator
     const EKFGSF_yaw *get_yaw_estimator(void) const;
 
+    // Return the param for status to record Position
+    int8_t get_pos_logging_status(void) {
+        return _pos_logging;
+    }
+
 private:
 
     // optional view class
@@ -646,6 +651,7 @@ private:
 
     AP_Enum<GPSUse> _gps_use;
     AP_Int8 _gps_minsats;
+    AP_Int8 _pos_logging;
 
     enum class EKFType {
         NONE = 0

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1145,12 +1145,10 @@ bool AP_AHRS::set_home(const Location &loc)
     _home_is_set = true;
 
     Log_Write_Home_And_Origin();
-    
-    if(!get_pos_logging_status()) {
-        // send new home and ekf origin to GCS
-        gcs().send_message(MSG_HOME);
-        gcs().send_message(MSG_ORIGIN);
-    }
+
+    // send new home and ekf origin to GCS
+    gcs().send_message(MSG_HOME);
+    gcs().send_message(MSG_ORIGIN);
 
     AP_HAL::Util::PersistentData &pd = hal.util->persistent_data;
     pd.home_lat = loc.lat;

--- a/libraries/AP_AHRS/AP_AHRS_DCM.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_DCM.cpp
@@ -1145,10 +1145,12 @@ bool AP_AHRS::set_home(const Location &loc)
     _home_is_set = true;
 
     Log_Write_Home_And_Origin();
-
-    // send new home and ekf origin to GCS
-    gcs().send_message(MSG_HOME);
-    gcs().send_message(MSG_ORIGIN);
+    
+    if(!get_pos_logging_status()) {
+        // send new home and ekf origin to GCS
+        gcs().send_message(MSG_HOME);
+        gcs().send_message(MSG_ORIGIN);
+    }
 
     AP_HAL::Util::PersistentData &pd = hal.util->persistent_data;
     pd.home_lat = loc.lat;

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -71,12 +71,21 @@ void AP_AHRS::Write_Attitude(const Vector3f &targets) const
 
 void AP_AHRS::Write_Origin(LogOriginType origin_type, const Location &loc) const
 {
+
+    int32_t lat = loc.lat;
+    int32_t lng = loc.lng;
+
+    if(!get_pos_logging_status()) {
+        lat = 0;
+        lng = 0;
+    }
+
     const struct log_ORGN pkt{
         LOG_PACKET_HEADER_INIT(LOG_ORGN_MSG),
         time_us     : AP_HAL::micros64(),
         origin_type : (uint8_t)origin_type,
-        latitude    : loc.lat,
-        longitude   : loc.lng,
+        latitude    : lat,
+        longitude   : lng,
         altitude    : loc.alt
     };
     AP::logger().WriteBlock(&pkt, sizeof(pkt));

--- a/libraries/AP_AHRS/AP_AHRS_Logging.cpp
+++ b/libraries/AP_AHRS/AP_AHRS_Logging.cpp
@@ -14,6 +14,12 @@ void AP_AHRS::Write_AHRS2() const
     if (!get_secondary_attitude(euler) || !get_secondary_position(loc) || !get_secondary_quaternion(quat)) {
         return;
     }
+    // if we are not logging, zero out the location
+    if(!get_pos_logging_status()) {
+        loc.lat = 0;
+        loc.lng = 0;
+    }
+
     const struct log_AHRS pkt{
         LOG_PACKET_HEADER_INIT(LOG_AHR2_MSG),
         time_us : AP_HAL::micros64(),
@@ -85,6 +91,14 @@ void AP_AHRS::Write_POS() const
     }
     float home, origin;
     AP::ahrs().get_relative_position_D_home(home);
+
+    // if we are not logging, zero out the location
+    if(!get_pos_logging_status()) {
+        loc.lat = 0;
+        loc.lng = 0;
+        home = 0;        
+    }
+
     const struct log_POS pkt{
         LOG_PACKET_HEADER_INIT(LOG_POS_MSG),
         time_us        : AP_HAL::micros64(),


### PR DESCRIPTION
This is a PR to stop logging Lattitude and Longitude in the Logs.
Changes made:
Adding a new param AHRS_POS_LOG default set to 0 (0: false & 1: true).
Ensure the lat and long data is sanitised to 0 while logging.
Make sure the Origin/Home pos is not recorded

Testing:
**When AHRS_POS_LOG is True i.e 1**
_Latitude:_

![image](https://github.com/user-attachments/assets/73ccd6b6-5c43-4db7-b167-fa19ab5d71c7)

_Longitude:_

![image](https://github.com/user-attachments/assets/b9f16fe2-1dd4-4acb-89e8-e977ad47955d)

**When AHRS_POS_LOG  is False i.e 0**

_Latitude:_

![image](https://github.com/user-attachments/assets/f1fe7580-45c6-49ae-87c6-53c9160932f1)

_Longitude:_

![image](https://github.com/user-attachments/assets/c6998cf0-9304-44f3-831a-cdf9e8000ebf)

Not storing the Origin data:
![image](https://github.com/user-attachments/assets/cd14e3aa-17d5-4035-a1ca-f6a90e17c599)

