### PR TITLE
Changing the version to 4.3.0.9

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -7,7 +7,7 @@
 #include "ap_version.h"
 
 
-#define THISFIRMWARE "MA V4.3.0.8-DEV"
+#define THISFIRMWARE "MA V4.3.0.9"
 
 
 // the following line is parsed by the autotest scripts


### PR DESCRIPTION
Changing the build version to 4.3.0.9 based on the testing done in field all the data is at location:
[Ukr Removing Logs](https://malloyaeronautics2022.sharepoint.com/:f:/r/sites/MalloyAeroHome/Shared%20Documents/TRV150/Testing/Ukraine%20Remove%20Logging?csf=1&web=1&e=3LdEcd)