### PR TITLE
Increasing the timeout to 15500ms

### DIFF
--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_MAVLink.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_MAVLink.cpp
@@ -23,7 +23,7 @@
 #include <AP_Baro/AP_Baro.h>
 #include <AP_AHRS/AP_AHRS.h>
 
-#define ADSB_CHAN_TIMEOUT_MS            15000
+#define ADSB_CHAN_TIMEOUT_MS            15500
 
 
 extern const AP_HAL::HAL& hal;


### PR DESCRIPTION
We were intermittently getting the error from the driver:
**"ADSB: Transceiver heartbeat timed out"**

On further checking how much the difference for the timeout that occurs for this error we saw:
04/06/2025 11:33:32 : ADSB: Transceiver heartbeat timed out
04/06/2025 11:33:32 : ADSB: Delay is : **15005 ms** --> **diff of 5ms**

04/06/2025 11:40:16 : ADSB: Transceiver heartbeat timed out
04/06/2025 11:40:16 : ADSB: Delay is : 15098 ms --> **diff of 98ms**

04/06/2025 11:29:54 : ADSB: Transceiver heartbeat timed out
04/06/2025 11:29:54 : ADSB: Delay is : 15008 ms --> **diff of 8ms**

Increasing the timeout by 500ms this issue was not coming through.

To verify if this works please build the code and run the flight controller for 30 min