### PR TITLE
Adsb no dynamic messages

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -7,7 +7,7 @@
 #include "ap_version.h"
 
 
-#define THISFIRMWARE "MEX-V4.3.0.10"
+#define THISFIRMWARE "DEV-MEX-V4.3.0.11"
 
 
 // the following line is parsed by the autotest scripts

--- a/libraries/AP_ADSB/AP_ADSB.cpp
+++ b/libraries/AP_ADSB/AP_ADSB.cpp
@@ -165,6 +165,13 @@ const AP_Param::GroupInfo AP_ADSB::var_info[] = {
     // @User: Advanced
     AP_GROUPINFO("OPTIONS",  15, AP_ADSB, _options, 0),
 
+    // @Param: DYN_OUT
+    // @DisplayName: ADS-B Options
+    // @Description: This is to disable UAVIONIX_ADSB_OUT_DYNAMIC (10002) messages. This is for issue we observed on ping1090i where it would not accept these messages.
+    // @Values: 0:Disable dynamic messages,1:Enable dynamic messages
+    // @User: Advanced
+    AP_GROUPINFO("DYN_OUT",  16, AP_ADSB, _dyn_out_messages_enabled, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_ADSB/AP_ADSB.h
+++ b/libraries/AP_ADSB/AP_ADSB.h
@@ -296,6 +296,10 @@ private:
 
     // logging
     AP_Int8 _log;
+
+    // when true, we send dynamic out messages to the adsb transciever (10002)
+    AP_Int8 _dyn_out_messages_enabled;
+
     void write_log(const adsb_vehicle_t &vehicle) const;
     enum logging {
         NONE            = 0,

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_MAVLink.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_MAVLink.cpp
@@ -57,8 +57,10 @@ void AP_ADSB_uAvionix_MAVLink::update()
         // send dynamic data to transceiver at 5Hz
         if (now - _frontend.out_state.last_report_ms >= 200 && HAVE_PAYLOAD_SPACE(chan, UAVIONIX_ADSB_OUT_DYNAMIC)) {
             _frontend.out_state.last_report_ms = now;
-            // Commenting this for ADSB ping1090i as it has its own gps and accelerometer (Abhishek Saxena)
-            // send_dynamic_out(chan);
+            // for ADSB ping1090i we should not send dynamic messages, set AP_ADSB_DYN_OUT param to 0
+            if (_frontend._dyn_out_messages_enabled == 1) {
+                send_dynamic_out(chan);
+            }
         } // last_report_ms
     } // chan_last_ms
 }

--- a/libraries/AP_ADSB/AP_ADSB_uAvionix_MAVLink.cpp
+++ b/libraries/AP_ADSB/AP_ADSB_uAvionix_MAVLink.cpp
@@ -57,7 +57,8 @@ void AP_ADSB_uAvionix_MAVLink::update()
         // send dynamic data to transceiver at 5Hz
         if (now - _frontend.out_state.last_report_ms >= 200 && HAVE_PAYLOAD_SPACE(chan, UAVIONIX_ADSB_OUT_DYNAMIC)) {
             _frontend.out_state.last_report_ms = now;
-            send_dynamic_out(chan);
+            // Commenting this for ADSB ping1090i as it has its own gps and accelerometer (Abhishek Saxena)
+            // send_dynamic_out(chan);
         } // last_report_ms
     } // chan_last_ms
 }


### PR DESCRIPTION
This is to prevent sending the [UAVIONIX_ADSB_OUT_DYNAMIC](https://mavlink.io/en/messages/uAvionix.html) (**10002**) from being sent to the UAvionix ping 1090i transceiver.

 We observed a drop in data from ADSB transceiver when this packet is sent.

The way I have approached it is:
- Creating a new param ADSB_DYN_OUT with values 0 (Disable) and 1(Enable).
- Check the parameter before calling the function to send the MAVLink packet to the transceiver.

Why do we not need to send this MAVLink packet? 
Because the ping1090i has its own GPS and accelerometer, it can create this packet and broadcast the information.
The driver was written for an older version that did not have its own GPS.

What information does ADSB_DYN_OUT  have?
The MAVLink packet contains the dynamic information of POSITION, GPS Status, Squawk ID and Velocity in all directions for other transceivers to track