### PR TITLE
Lightware serial ldf ldl implementation

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -7,7 +7,7 @@
 #include "ap_version.h"
 
 
-#define THISFIRMWARE "MEX-V4.3.0.10"
+#define THISFIRMWARE "DEV-LIDAR-V4.3.0.11"
 
 
 // the following line is parsed by the autotest scripts

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -1282,7 +1282,7 @@ LOG_STRUCTURE_FROM_CAMERA \
     { LOG_RFND_MSG, sizeof(log_RFND), \
       "RFND", "QBCBB", "TimeUS,Instance,Dist,Stat,Orient", "s#m--", "F-B--", true }, \
     { LOG_LRD1_MSG, sizeof(log_LRD1), \
-      "LRD1", "QCCCCBBB", "TimeUS,Dis24,Dis60,DisInt,DisLpf,Snr24,Snr60,SnrInt", "smmmm---", "FHHHH---", true }, \
+      "LRD1", "QCCCCBBB", "TimeUS,Dis24,Dis60,DisInt,DisLpf,Snr24,Snr60,SnrInt", "smmmm---", "FBBBB---", true }, \
     { LOG_LW20_MSG, sizeof(log_LW20), \
       "LW20", "Qfff", "TimeUS,DisLdf,DisLdl,DisInt", "smmm", "F000", true }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \

--- a/libraries/AP_Logger/LogStructure.h
+++ b/libraries/AP_Logger/LogStructure.h
@@ -477,6 +477,18 @@ struct PACKED log_LRD1
 };
 
 /*
+  rangefinder - Logging LW20C Lidar Alt
+*/
+struct PACKED log_LW20
+{
+  LOG_PACKET_HEADER;
+  uint64_t time_us;
+  float dist_ldf_m;  // Distance first from lidar m
+  float dist_ldl_m;  // Distance last from lidar m
+  float dist_int_m;  // Distance selected as the reading m
+};
+
+/*
   terrain log structure
  */
 struct PACKED log_TERRAIN {
@@ -1271,6 +1283,8 @@ LOG_STRUCTURE_FROM_CAMERA \
       "RFND", "QBCBB", "TimeUS,Instance,Dist,Stat,Orient", "s#m--", "F-B--", true }, \
     { LOG_LRD1_MSG, sizeof(log_LRD1), \
       "LRD1", "QCCCCBBB", "TimeUS,Dis24,Dis60,DisInt,DisLpf,Snr24,Snr60,SnrInt", "smmmm---", "FHHHH---", true }, \
+    { LOG_LW20_MSG, sizeof(log_LW20), \
+      "LW20", "Qfff", "TimeUS,DisLdf,DisLdl,DisInt", "smmm", "F000", true }, \
     { LOG_MAV_STATS, sizeof(log_MAV_Stats), \
       "DMS", "QIIIIBBBBBBBBB",         "TimeUS,N,Dp,RT,RS,Fa,Fmn,Fmx,Pa,Pmn,Pmx,Sa,Smn,Smx", "s-------------", "F-------------" }, \
     LOG_STRUCTURE_FROM_BEACON                                       \
@@ -1393,6 +1407,7 @@ enum LogMessages : uint8_t {
     LOG_IDS_FROM_RPM,
     LOG_RFND_MSG,
     LOG_LRD1_MSG,
+    LOG_LW20_MSG,
     LOG_MAV_STATS,
     LOG_FORMAT_UNITS_MSG,
     LOG_UNIT_MSG,

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Backend.h
@@ -50,6 +50,7 @@ public:
     int8_t lrd1_lpf_window() const { return params.lrd1_lpf_window; }
     void set_lrd1_cur_pos(int8_t pos){ params.lrd1_cur_pos = pos; }
     int8_t get_lrd1_cur_pos(){ return params.lrd1_cur_pos; }
+    int8_t lw20_distance_mode() const{ return params.lw20_distance_mode;}
 
     // Function to be called to update reading and calculate average
     float get_avg_reading(float new_reading);

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -157,6 +157,19 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
     if (valid_count > 0) {
         reading_m = sum / valid_count;
         no_signal = false;
+        // log the data
+        if (valid_count_ldf > 0){
+            ldf_reading_m = sum_ldf / valid_count_ldf;
+        }
+        if (valid_count_ldl > 0){
+            ldl_reading_m = sum_ldl / valid_count_ldl;
+        }
+#if HAL_LOGGING_ENABLED
+        Log_LW20_C(
+            ldf_reading_m,
+            ldl_reading_m,
+            reading_m);
+#endif
         return true;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -159,6 +159,53 @@ bool AP_RangeFinder_LightWareSerial::is_lost_signal_distance(int16_t distance_cm
     return false;
 }
 
+/*
+This is a function to extract the distance reported by the LW20 for commands ldf and ldl
+Return: 
+0 if the reply is not valid
+1 if the reply is for ldf 
+2 if the reply is for ldl
+*/
+int8_t AP_RangeFinder_LightWareSerial::get_distance_from_lidar_reply(char reply[], float &distance_m)
+{
+    // Parse the data stream
+    int8_t channel = 0; // 1 for ldf and 2 for ldl
+
+    // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "1. reply: %s", reply);
+    
+    char* token = strtok(reply, ",:");
+
+    if (token == nullptr) {
+        return -1;
+    }
+
+    token = strtok(nullptr, ",:");
+    if (token == nullptr) {
+        return -1;
+    }
+    channel = atoi(token);
+    if (channel == 0) {
+        return -1;
+    }
+
+    token = strtok(nullptr, ",:"); // get the part after the colon
+    if (token == nullptr) {
+        channel = -1;
+    }
+
+    char *distance_str = token;
+    distance_m = strtof(distance_str, nullptr); // Convert to meters
+
+    if (channel == 1) {
+        ldf_val_m = distance_m; // Store the first reading in cm
+    } else if (channel == 2) {
+        ldl_val_m = distance_m; // Store the last reading in cm
+    } else {
+        channel = -1; // Invalid channel
+    }
+    return channel;
+}
+
 void AP_RangeFinder_LightWareSerial::Log_LW20_C(
     float ldf_m, float ldl_m, float integrated_m)
 {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -57,7 +57,7 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
                 linebuf[linebuf_len] = 0;
                 float dist = 0;
                 int8_t lidar_reply_type = get_distance_from_lidar_reply(linebuf, dist);
-                if (lidar_reply_type == -1) {
+                if (lidar_reply_type == 0) {
                     // invalid reading
                     invalid_count++;
                     // reset the buffer length and clear the buffer
@@ -66,16 +66,15 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
                     continue;
                 }
                 else if (!is_negative(dist) && !is_lost_signal_distance(dist * 100, distance_cm_max)) {
-                    if (lidar_reply_type == 1) {
-                        sum_ldf += ldf_val_m;
+                    if (lidar_reply_type == 1) { 
+                        sum_ldf += ldf_val_m; // summing LDF value
                         valid_count_ldf++;
                     } else if (lidar_reply_type == 2) {
-                        sum_ldl += ldl_val_m;
+                        sum_ldl += ldl_val_m; // summing LDL value
                         valid_count_ldl++;
                     }
                     // overall sum and count
                     if (lidar_reply_type == 1  && ldf_val_m < (distance_lpf_min_cm*0.01f) && ldl_val_m > 0) {
-                        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Incorrect LDF :: %f so LDL : %f", ldf_val_m, ldl_val_m);
                         sum += float(ldl_val_m); // use the stored ldl reading if available
                         valid_count++;
                     } else if(lidar_reply_type == 1) {
@@ -209,40 +208,39 @@ Return:
 */
 int8_t AP_RangeFinder_LightWareSerial::get_distance_from_lidar_reply(char reply[], float &distance_m)
 {
-    // Parse the data stream
+    // Parse the data stream format ldl,2:0.55 or ldf,1:0.45
     int8_t channel = 0; // 1 for ldf and 2 for ldl
 
-    // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "1. reply: %s", reply);
     
     char* token = strtok(reply, ",:");
 
     if (token == nullptr) {
-        return -1;
+        return channel;
     }
 
     token = strtok(nullptr, ",:");
     if (token == nullptr) {
-        return -1;
+        return channel;
     }
     channel = atoi(token);
     if (channel == 0) {
-        return -1;
+        return channel;
     }
 
     token = strtok(nullptr, ",:"); // get the part after the colon
     if (token == nullptr) {
-        channel = -1;
+        channel = channel;
     }
 
     char *distance_str = token;
     distance_m = strtof(distance_str, nullptr); // Convert to meters
 
     if (channel == 1) {
-        ldf_val_m = distance_m; // Store the first reading in cm
+        ldf_val_m = distance_m; // Store the first reading in m
     } else if (channel == 2) {
-        ldl_val_m = distance_m; // Store the last reading in cm
+        ldl_val_m = distance_m; // Store the last reading in m
     } else {
-        channel = -1; // Invalid channel
+        channel = 0; // Invalid channel
     }
     return channel;
 }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -32,7 +32,7 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
         return false;
     }
 
-    float sum = 0;              // sum of all readings taken
+    float sum_auto = 0;           // sum of integrated mode if (VAL > ground clearance) ? ldf : ldl
     float sum_ldf = 0;          // sum of ldf readings taken
     float sum_ldl = 0;          // sum of ldl readings taken
     uint16_t valid_count = 0;   // number of valid readings
@@ -41,6 +41,7 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
     uint16_t invalid_count = 0; // number of invalid readings
     float ldf_reading_m = 0;
     float ldl_reading_m = 0;
+    float auto_reading_m = 0;
 
     // max distance the sensor can reliably measure - read from parameters
     const int16_t distance_cm_max = max_distance_cm();
@@ -75,10 +76,10 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
                     }
                     // overall sum and count
                     if (lidar_reply_type == 1  && ldf_val_m < (distance_lpf_min_cm*0.01f) && ldl_val_m > 0) {
-                        sum += float(ldl_val_m); // use the stored ldl reading if available
+                        sum_auto += float(ldl_val_m); // use the stored ldl reading if available
                         valid_count++;
                     } else if(lidar_reply_type == 1) {
-                        sum += dist;
+                        sum_auto += dist;
                         valid_count++;
                     }
 
@@ -113,7 +114,7 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
                 if (high_byte_received) {
                     const int16_t dist = (high_byte & 0x7f) << 7 | (c & 0x7f);
                     if (dist >= 0 && !is_lost_signal_distance(dist, distance_cm_max)) {
-                        sum += dist * 0.01f;
+                        sum_auto += dist * 0.01f;
                         valid_count++;
                         // if still determining protocol update binary valid count
                         if (protocol_state == ProtocolState::UNKNOWN) {
@@ -154,8 +155,7 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
 
     // return average of all valid readings
     if (valid_count > 0) {
-        reading_m = sum / valid_count;
-        no_signal = false;
+        auto_reading_m = sum_auto / valid_count;
         // log the data
         if (valid_count_ldf > 0){
             ldf_reading_m = sum_ldf / valid_count_ldf;
@@ -163,12 +163,20 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
         if (valid_count_ldl > 0){
             ldl_reading_m = sum_ldl / valid_count_ldl;
         }
+        // chose the reading based on LW20MODE param
+        if(lw20_distance_mode() == 1)
+            reading_m = ldf_reading_m;
+        else if (lw20_distance_mode() == 2)
+            reading_m = ldl_reading_m;
+        else
+            reading_m = auto_reading_m;
 #if HAL_LOGGING_ENABLED
         Log_LW20_C(
             ldf_reading_m,
             ldl_reading_m,
-            reading_m);
+            auto_reading_m);
 #endif
+        no_signal = false;
         return true;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -33,11 +33,18 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
     }
 
     float sum = 0;              // sum of all readings taken
+    float sum_ldf = 0;          // sum of ldf readings taken
+    float sum_ldl = 0;          // sum of ldl readings taken
     uint16_t valid_count = 0;   // number of valid readings
+    uint16_t valid_count_ldf = 0; // number of valid ldf readings
+    uint16_t valid_count_ldl = 0; // number of valid ldl readings
     uint16_t invalid_count = 0; // number of invalid readings
+    float ldf_reading_m = 0;
+    float ldl_reading_m = 0;
 
     // max distance the sensor can reliably measure - read from parameters
     const int16_t distance_cm_max = max_distance_cm();
+    const int16_t distance_lpf_min_cm = ground_clearance_cm();
 
     // read any available lines from the lidar
     int16_t nbytes = uart->available();

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -216,10 +216,9 @@ Return:
 */
 int8_t AP_RangeFinder_LightWareSerial::get_distance_from_lidar_reply(char reply[], float &distance_m)
 {
-    // Parse the data stream format ldl,2:0.55 or ldf,1:0.45
     int8_t channel = 0; // 1 for ldf and 2 for ldl
-
-    
+    char tmp_ch = reply[4];
+    // Parse the data stream format ldl,2:0.55 or ldf,1:0.45
     char* token = strtok(reply, ",:");
 
     if (token == nullptr) {
@@ -230,7 +229,11 @@ int8_t AP_RangeFinder_LightWareSerial::get_distance_from_lidar_reply(char reply[
     if (token == nullptr) {
         return channel;
     }
-    channel = atoi(token);
+
+    if(isdigit(tmp_ch)){
+        channel = atoi(tmp_ch);
+    }
+
     if (channel == 0) {
         return channel;
     }

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -76,7 +76,7 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
                     }
                     // overall sum and count
                     if (lidar_reply_type == 1  && ldf_val_m < (distance_lpf_min_cm*0.01f) && ldl_val_m > 0) {
-                        sum_auto += float(ldl_val_m); // use the stored ldl reading if available
+                        sum_auto += ldl_val_m; // use the stored ldl reading if available
                         valid_count++;
                     } else if(lidar_reply_type == 1) {
                         sum_auto += dist;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -159,4 +159,17 @@ bool AP_RangeFinder_LightWareSerial::is_lost_signal_distance(int16_t distance_cm
     return false;
 }
 
+void AP_RangeFinder_LightWareSerial::Log_LW20_C(
+    float ldf_m, float ldl_m, float integrated_m)
+{
+    const struct log_LW20 pkt = {
+        LOG_PACKET_HEADER_INIT(LOG_LW20_MSG),
+        time_us : AP_HAL::micros64(),
+        dist_ldf_m : ldf_m,
+        dist_ldl_m : ldl_m,
+        dist_int_m : integrated_m,
+    };
+    AP::logger().WriteBlock(&pkt, sizeof(pkt));
+}
+
 #endif

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -55,10 +55,34 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
         if (protocol_state == ProtocolState::UNKNOWN || protocol_state == ProtocolState::LEGACY) {
             if (c == '\r') {
                 linebuf[linebuf_len] = 0;
-                const float dist = strtof(linebuf, nullptr);
-                if (!is_negative(dist) && !is_lost_signal_distance(dist * 100, distance_cm_max)) {
-                    sum += dist;
-                    valid_count++;
+                float dist = 0;
+                int8_t lidar_reply_type = get_distance_from_lidar_reply(linebuf, dist);
+                if (lidar_reply_type == -1) {
+                    // invalid reading
+                    invalid_count++;
+                    // reset the buffer length and clear the buffer
+                    linebuf_len = 0;
+                    memset(linebuf, 0, sizeof(linebuf));
+                    continue;
+                }
+                else if (!is_negative(dist) && !is_lost_signal_distance(dist * 100, distance_cm_max)) {
+                    if (lidar_reply_type == 1) {
+                        sum_ldf += ldf_val_m;
+                        valid_count_ldf++;
+                    } else if (lidar_reply_type == 2) {
+                        sum_ldl += ldl_val_m;
+                        valid_count_ldl++;
+                    }
+                    // overall sum and count
+                    if (lidar_reply_type == 1  && ldf_val_m < (distance_lpf_min_cm*0.01f) && ldl_val_m > 0) {
+                        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Incorrect LDF :: %f so LDL : %f", ldf_val_m, ldl_val_m);
+                        sum += float(ldl_val_m); // use the stored ldl reading if available
+                        valid_count++;
+                    } else if(lidar_reply_type == 1) {
+                        sum += dist;
+                        valid_count++;
+                    }
+
                     // if still determining protocol update legacy valid count
                     if (protocol_state == ProtocolState::UNKNOWN) {
                         legacy_valid_count++;
@@ -67,11 +91,13 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
                     invalid_count++;
                 }
                 linebuf_len = 0;
-            } else if (isdigit(c) || c == '.' || c == '-') {
+                memset(linebuf, 0, sizeof(linebuf));
+            }else if(isdigit(c) || c == '.' || c == '-' || c == 'l' || c == 'd' || c == 'f' || c == ',' || c == ':'){
                 linebuf[linebuf_len++] = c;
                 if (linebuf_len == sizeof(linebuf)) {
                     // too long, discard the line
                     linebuf_len = 0;
+                    memset(linebuf, 0, sizeof(linebuf));
                 }
             }
         }
@@ -122,7 +148,9 @@ bool AP_RangeFinder_LightWareSerial::get_reading(float &reading_m)
         uart->write("www\r\n");
         last_init_ms = now;
     } else {
-        uart->write('d');
+        // Sending LDL before LDF is required
+        uart->write("?LDL,2\r\n");
+        uart->write("?LDF,1\r\n");
     }
 
     // return average of all valid readings

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -38,11 +38,13 @@ private:
     bool get_reading(float &reading_m) override;
     bool is_lost_signal_distance(int16_t distance_cm, int16_t distance_cm_max);
 
-    char linebuf[10];           // legacy protocol buffer
+    char linebuf[50];           // legacy protocol buffer
     uint8_t linebuf_len;        // legacy protocol buffer length
     uint32_t last_init_ms;      // init time used to switch lw20 to serial mode
     uint8_t high_byte;          // binary protocol high byte
     bool high_byte_received;    // true if high byte has been received
+    float ldf_val_m;        // lidar first reading in m
+    float ldl_val_m;        // lidar last reading in m
 
     // automatic protocol decision variables
     enum class ProtocolState {

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -3,6 +3,8 @@
 #include "AP_RangeFinder.h"
 #include "AP_RangeFinder_Backend_Serial.h"
 
+#include <AP_Logger/AP_Logger.h>
+
 #ifndef AP_RANGEFINDER_LIGHTWARE_SERIAL_ENABLED
 #define AP_RANGEFINDER_LIGHTWARE_SERIAL_ENABLED AP_RANGEFINDER_BACKEND_DEFAULT_ENABLED
 #endif
@@ -37,6 +39,7 @@ private:
     // get a reading
     bool get_reading(float &reading_m) override;
     bool is_lost_signal_distance(int16_t distance_cm, int16_t distance_cm_max);
+    int8_t get_distance_from_lidar_reply(char *reply, float &distance_m);
     // Logging Function
     void Log_LW20_C(float ldf_reading_cm, float ldl_reading_cm, float integrated_reading_cm);
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.h
@@ -37,6 +37,8 @@ private:
     // get a reading
     bool get_reading(float &reading_m) override;
     bool is_lost_signal_distance(int16_t distance_cm, int16_t distance_cm_max);
+    // Logging Function
+    void Log_LW20_C(float ldf_reading_cm, float ldl_reading_cm, float integrated_reading_cm);
 
     char linebuf[50];           // legacy protocol buffer
     uint8_t linebuf_len;        // legacy protocol buffer length

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.cpp
@@ -153,6 +153,13 @@ const AP_Param::GroupInfo AP_RangeFinder_Params::var_info[] = {
     // @User: Standard
     AP_GROUPINFO("LRD1WND", 55, AP_RangeFinder_Params, lrd1_lpf_window, 5),
 
+    // @Param: LW20MODE
+    // @DisplayName: LW20 Lidar Mode 
+    // @Description: LW20 get the First return, Last return or Auto mode where if (value > Ground Clearance)? First Return : Last Return 
+    // @Values: 0:Auto, 1:LPF, 2:LDL
+    // @User: Advanced
+    AP_GROUPINFO("LW20MODE", 56, AP_RangeFinder_Params, lw20_distance_mode, 0),
+
     AP_GROUPEND
 };
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_Params.h
@@ -15,7 +15,7 @@ public:
     AP_RangeFinder_Params(const AP_RangeFinder_Params &other) = delete;
     AP_RangeFinder_Params &operator=(const AP_RangeFinder_Params&) = delete;
 
-    AP_Vector3f pos_offset; // position offset in body frame
+    AP_Vector3f pos_offset;     // position offset in body frame
     AP_Float scaling;
     AP_Float offset;
     AP_Int16 powersave_range;
@@ -29,10 +29,9 @@ public:
     AP_Int8  ground_clearance_cm;
     AP_Int8  address;
     AP_Int8  orientation;
-    // LRD1 frequency mode (24GHz of Integrated)
-    AP_Int8  lrd1_freq_mode;
-    // LRD1 Low pass filter window size (1-20)
-    AP_Int8  lrd1_lpf_window;
+    AP_Int8  lrd1_freq_mode;    // LRD1 frequency mode (24GHz of Integrated)
+    AP_Int8  lrd1_lpf_window;   // LRD1 Low pass filter window size (1-20)
+    AP_Int8  lw20_distance_mode;  // LW20C Lidar return type
     int8_t lrd1_cur_pos;
     float _range_window[MAX_WINDOW_SIZE];  // Static array for readings
 };


### PR DESCRIPTION
Objective:
Instead of getting just the numeric value (command 'd', type: first point ldf ) from Lidar we need to get the LDF(first return) and the LDL(last return).
The reading reported by the lidar will be first return (LDF) unless the reported data < Ground clearance value in the parameter (for T150 is 55cm).
for future proofing: we will create a new param to use the type of data (ldf or ldl or both) from the lidar.
 
Work on the driver:
Logic to get the data from the lidar over 2 channels LDF on Ch1 and LDL on Ch2.
parse the data streamed in the format ldl,1:<val> and ldf,2:<val>
check if the ldf val < ground clearance, true: use the ldl value else use the ldf value
Create logging method for storing these value
Create new param for the user to select the data type

Testing:

<img width="1870" height="592" alt="image" src="https://github.com/user-attachments/assets/06285285-d417-4c86-8aeb-a9721af73689" />

