### PR TITLE
[NHW] Improve GPS source handling on dropouts.

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -7,7 +7,7 @@
 #include "ap_version.h"
 
 
-#define THISFIRMWARE "MEX-V4.3.0.10"
+#define THISFIRMWARE "MA_Copter-V4.3.0.11_dev"
 
 
 // the following line is parsed by the autotest scripts

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -7,7 +7,7 @@
 #include "ap_version.h"
 
 
-#define THISFIRMWARE "MA_Copter-V4.3.0.11_dev"
+#define THISFIRMWARE "MA_Copter-V4.3.0.11_PreRelease"
 
 
 // the following line is parsed by the autotest scripts

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1152,8 +1152,12 @@ void AP_GPS::update_primary(void)
     for (uint8_t i=0; i<GPS_MAX_RECEIVERS; i++) {
         if (((_type[i] == GPS_TYPE_UBLOX_RTK_BASE) || (_type[i] == GPS_TYPE_UAVCAN_RTK_BASE)) &&
             ((_type[i^1] == GPS_TYPE_UBLOX_RTK_ROVER) || (_type[i^1] == GPS_TYPE_UAVCAN_RTK_ROVER)) &&
-            ((state[i].status >= GPS_OK_FIX_3D) || (state[i].status >= state[i^1].status))) {
+            ((state[i].status >= GPS_OK_FIX_3D) || (state[i].status >= state[i^1].status)) && 
+            // [NHW] Added in checks for GPS performance before switching to check it's not donkey
+            ((state[i].vertical_accuracy <= 1.0) || (state[i].vertical_accuracy <= state[i^1].vertical_accuracy)) &&
+            ((state[i].horizontal_accuracy <= 1.0) || (state[i].horizontal_accuracy <= state[i^1].horizontal_accuracy))) {
             if (primary_instance != i) {
+
                 _last_instance_swap_ms = now;
                 primary_instance = i;
             }
@@ -1215,26 +1219,31 @@ void AP_GPS::update_primary(void)
         if (i == primary_instance) {
             continue;
         }
-        if (state[i].status > state[primary_instance].status) {
-            // we have a higher status lock, or primary is set to the blended GPS, change GPS
+        if ((state[i].status > state[primary_instance].status) &&
+            // [NHW] adding in additional health check for GPS status before switching
+            ((state[i].vertical_accuracy <= 1.0) || (state[i].vertical_accuracy <= state[primary_instance].vertical_accuracy)) &&
+            ((state[i].horizontal_accuracy <= 1.0) || (state[i].horizontal_accuracy <= state[primary_instance].horizontal_accuracy))) {
+            // we have a higher status lock (plus the additional performance checks), or primary is set to the blended GPS, change GPS
             primary_instance = i;
             _last_instance_swap_ms = now;
             continue;
         }
 
         bool another_gps_has_1_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 1);
-
-        if (state[i].status == state[primary_instance].status && another_gps_has_1_or_more_sats) {
+        // [NHW] Add check for better accuracy
+        bool another_gps_has_better_accuracy =  ((state[i].vertical_accuracy <= state[primary_instance].vertical_accuracy) && (state[i].horizontal_accuracy <= state[primary_instance].horizontal_accuracy));
+        if (state[i].status == state[primary_instance].status && another_gps_has_1_or_more_sats && another_gps_has_better_accuracy) {
 
             bool another_gps_has_2_or_more_sats = (state[i].num_sats >= state[primary_instance].num_sats + 2);
 
-            if ((another_gps_has_1_or_more_sats && (now - _last_instance_swap_ms) >= 20000) ||
-                (another_gps_has_2_or_more_sats && (now - _last_instance_swap_ms) >= 5000)) {
+            if ((another_gps_has_1_or_more_sats && another_gps_has_better_accuracy && (now - _last_instance_swap_ms) >= 20000) ||
+                (another_gps_has_2_or_more_sats && another_gps_has_better_accuracy && (now - _last_instance_swap_ms) >= 5000)) {
                 // this GPS has more satellites than the
                 // current primary, switch primary. Once we switch we will
                 // then tend to stick to the new GPS as primary. We don't
                 // want to switch too often as it will look like a
                 // position shift to the controllers.
+                // [NHW] Also now checks for better accuracy before it does this.
                 primary_instance = i;
                 _last_instance_swap_ms = now;
             }

--- a/libraries/AP_GPS/AP_GPS.cpp
+++ b/libraries/AP_GPS/AP_GPS.cpp
@@ -1157,7 +1157,6 @@ void AP_GPS::update_primary(void)
             ((state[i].vertical_accuracy <= 1.0) || (state[i].vertical_accuracy <= state[i^1].vertical_accuracy)) &&
             ((state[i].horizontal_accuracy <= 1.0) || (state[i].horizontal_accuracy <= state[i^1].horizontal_accuracy))) {
             if (primary_instance != i) {
-
                 _last_instance_swap_ms = now;
                 primary_instance = i;
             }

--- a/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
+++ b/libraries/AP_NavEKF3/AP_NavEKF3_Measurements.cpp
@@ -1114,15 +1114,30 @@ void NavEKF3_core::update_gps_selection(void)
     // in normal operation use the primary GPS
     selected_gps = gps.primary_sensor();
     preferred_gps = selected_gps;
-
+    
     if (frontend->_affinity & EKF_AFFINITY_GPS) {
         if (core_index < gps.num_sensors() ) {
             // always prefer our core_index, unless we don't have that
             // many GPS sensors available
             preferred_gps = core_index;
         }
-        if (gps.status(preferred_gps) >= AP_DAL_GPS::GPS_OK_FIX_3D) {
-            // select our preferred_gps if it has a 3D fix, otherwise
+
+    // [NHW] get the accuracies of the GPS instances
+    float vacc_preffered_gps = 0.0f;
+    float vacc_selected_gps = 0.0f;
+    float hacc_preffered_gps = 0.0f;
+    float hacc_selected_gps = 0.0f;
+    bool vacc_preffered_valid = gps.vertical_accuracy(preferred_gps, vacc_preffered_gps);
+    bool vacc_selected_valid = gps.vertical_accuracy(selected_gps, vacc_selected_gps);
+    bool hacc_preffered_valid = gps.horizontal_accuracy(preferred_gps, hacc_preffered_gps);
+    bool hacc_selected_valid = gps.vertical_accuracy(selected_gps, hacc_selected_gps);
+
+        // [NHW] Adding in additional checks for GPS performance before switching based only on the status. 
+        if ((gps.status(preferred_gps) >= AP_DAL_GPS::GPS_OK_FIX_3D) &&
+            ((vacc_preffered_valid && (vacc_preffered_gps <= 1.0)) || (vacc_selected_valid && (vacc_preffered_gps <= vacc_selected_gps))) &&
+            ((hacc_preffered_valid && (hacc_preffered_gps <= 1.0)) || (hacc_selected_valid && (hacc_preffered_gps <= hacc_selected_gps)))) 
+            {
+            // select our preferred_gps if it has a 3D fix (and now also checking the accuracy), otherwise
             // use the primary GPS
             selected_gps = preferred_gps;
         }


### PR DESCRIPTION
This fix addresses limitations in the switching logic used when multiple GPS instances are available to the EKF. 

Previously, the EKF will deem a GPS instance suitable for use based purely on the state of the preferred GPS exceeding a minimum status value. 

This change requires the switching logic to look for a minimum vertical and horizontal accuracy to be achieved before allowing a GPS to be used in the EKF state estimation. 

Failover and preferential performance characteristics are preserved. 