### PR TITLE
Fixing the issue of atoi(char) to atoi(char*)

### DIFF
--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareSerial.cpp
@@ -231,7 +231,7 @@ int8_t AP_RangeFinder_LightWareSerial::get_distance_from_lidar_reply(char reply[
     }
 
     if(isdigit(tmp_ch)){
-        channel = atoi(tmp_ch);
+        channel = atoi(token);
     }
 
     if (channel == 0) {


### PR DESCRIPTION
Last change for error check in the lidar ldf ldl driver I introduced an error:
atoi() expects a char* not char leading to the issue 