### PR TITLE
Adding retry code for the commands to I2C lidar

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -8,7 +8,7 @@
 
 
 
-#define THISFIRMWARE "MA_Copter-V4.3.0.11_PreRelease_LL"
+#define THISFIRMWARE "MA_Copter-V4.3.0.11"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -8,7 +8,7 @@
 
 
 
-#define THISFIRMWARE "DEV-MEX-I2C-V4.3.0.12"
+#define THISFIRMWARE "MA_COPTER-V4.3.0.12-DEV-I2C"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -8,7 +8,7 @@
 
 
 
-#define THISFIRMWARE "MA_Copter-V4.3.0.11"
+#define THISFIRMWARE "DEV-MEX-I2C-V4.3.0.12"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -120,23 +120,32 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
     const size_t expected_reply_len = strlen(expected_reply);
     uint8_t rx_bytes[expected_reply_len + 1];
     memset(rx_bytes, 0, sizeof(rx_bytes));
+    bool got_data = false;
 
     if ((expected_reply_len > lx20_max_reply_len_bytes) ||
         (expected_reply_len < 2)) {
         return false;
     }
 
-    if (!write_bytes((uint8_t*)send_msg,
-                     strlen(send_msg))) {
-        return false;
-    }
+    for (uint8_t i=0; i<5; i++ ) {
+        if (!write_bytes((uint8_t*)send_msg,
+                        strlen(send_msg))) {
+            continue;
+        }
 
-    if (!sf20_wait_on_reply(rx_bytes)) {
-        return false;
-    }
+        if (!sf20_wait_on_reply(rx_bytes)) {
+            continue;
+        }
 
-    if ((rx_bytes[0] != expected_reply[0]) ||
-        (rx_bytes[1] != expected_reply[1]) ) {
+        if ((rx_bytes[0] != expected_reply[0]) ||
+            (rx_bytes[1] != expected_reply[1]) ) {
+                continue;
+        } else {
+            got_data = true;
+            break;
+        }
+    }
+    if (!got_data) {
         return false;
     }
 

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -25,6 +25,7 @@ extern const AP_HAL::HAL& hal;
 #define LIGHTWARE_LOST_SIGNAL_TIMEOUT_READ_REG 22
 #define LIGHTWARE_LOST_SIGNAL_TIMEOUT_WRITE_REG 23
 #define LIGHTWARE_TIMEOUT_REG_DESIRED_VALUE 20      // number of lost signal confirmations for legacy protocol only
+#define LIGHTWARE_I2C_SF20_RETRYS 5
 
 #define LIGHTWARE_OUT_OF_RANGE_ADD_CM   100
 
@@ -127,7 +128,7 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
         return false;
     }
 
-    for (uint8_t i=0; i<5; i++ ) {
+    for (uint8_t i=0; i<LIGHTWARE_I2C_SF20_RETRYS; i++ ) {
         if (!write_bytes((uint8_t*)send_msg,
                         strlen(send_msg))) {
             continue;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -110,6 +110,7 @@ bool AP_RangeFinder_LightWareI2C::write_bytes(uint8_t *write_buf_u8, uint32_t le
  */
 void AP_RangeFinder_LightWareI2C::sf20_disable_address_tagging()
 {
+    // Disables "address tagging" which starts every response with "0x66".
     sf20_send_and_expect("#CT,0\r\n", "c:0");
 }
 
@@ -121,23 +122,28 @@ bool AP_RangeFinder_LightWareI2C::sf20_send_and_expect(const char* send_msg, con
     const size_t expected_reply_len = strlen(expected_reply);
     uint8_t rx_bytes[expected_reply_len + 1];
     memset(rx_bytes, 0, sizeof(rx_bytes));
+    // Flag to indicate if we got valid data for our commands
     bool got_data = false;
 
     if ((expected_reply_len > lx20_max_reply_len_bytes) ||
         (expected_reply_len < 2)) {
         return false;
     }
-
+    
+    // Retry loop for command
     for (uint8_t i=0; i<LIGHTWARE_I2C_SF20_RETRYS; i++ ) {
+        // check for send command success
         if (!write_bytes((uint8_t*)send_msg,
                         strlen(send_msg))) {
             continue;
         }
 
+        // check for reply success
         if (!sf20_wait_on_reply(rx_bytes)) {
             continue;
         }
-
+        
+        // check if reply matches expected reply
         if ((rx_bytes[0] != expected_reply[0]) ||
             (rx_bytes[1] != expected_reply[1]) ) {
                 continue;

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -109,7 +109,7 @@ bool AP_RangeFinder_LightWareI2C::write_bytes(uint8_t *write_buf_u8, uint32_t le
  */
 void AP_RangeFinder_LightWareI2C::sf20_disable_address_tagging()
 {
-    sf20_send_and_expect("#CT,0\r\n", "ct:0");
+    sf20_send_and_expect("#CT,0\r\n", "c:0");
 }
 
 /*

--- a/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
+++ b/libraries/AP_RangeFinder/AP_RangeFinder_LightWareI2C.cpp
@@ -202,10 +202,12 @@ bool AP_RangeFinder_LightWareI2C::init()
 {
     if (sf20_init()) {
         DEV_PRINTF("Found SF20 native Lidar\n");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Found SF20 native Lidar\n");
         return true;
     }
     if (legacy_init()) {
         DEV_PRINTF("Found SF20 legacy Lidar\n");
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO,"Found SF20 legacy Lidar\n");
         return true;
     }
     DEV_PRINTF("SF20 not found\n");


### PR DESCRIPTION
There are 2 sets of protocol drivers in the LightwareI2C driver : 
1. **sf20 protocol driver** 
2. **Legacy protocol driver** 

The flow of code is:
1. Go into SF20 protocol driver.
2. Try to initialise the sf20 protocols by commands such as:
     - Setting measuring mode
     - Setting the streaming ON 
     - Change the laser state etc

If any of the commands fail, it will go into Legacy protocol driver that just publishes data. We do not know if it is ldl or ldf.

Issue Observed:
Sometimes when I am doing the initialising commands to the LidarI2C I get a garbage value acknowledgement:
`14/10/2025 09:37:12 : Unexpected reply �� to #SU,1`

This leads to coming out of the SF20 driver and go to the Legacy driver.

Solution:
If I get an incorrect reply from the sf20-protocol command, I retry **5 times**.

Observation:
It makes the sf20 driver more robust and uses the LDL reply 
<img width="302" height="340" alt="image" src="https://github.com/user-attachments/assets/ea8f2ee0-3944-4bc7-863f-05ab535233cc" />
Also observed CT command reply is in the formant c:
No such command was observed in the product guide:
[LW20-C Product Guide](chrome-extension://efaidnbmnnnibpcajpcglclefindmkaj/https://lightwarelidar.com/wp-content/uploads/2025/06/LW20-Product-Guide-V13.2.pdf)

All the autotest regression tests results are recorded: **Malloy Aero Home - Documents\TRV150\FW Autotest\lightware-i2c-sf20-retry**