### PR TITLE
Use shared get_shaping_jerk_xy_cmsss function in pos control

### DIFF
--- a/libraries/AC_AttitudeControl/AC_PosControl.cpp
+++ b/libraries/AC_AttitudeControl/AC_PosControl.cpp
@@ -418,7 +418,7 @@ void AC_PosControl::set_max_speed_accel_xy(float speed_cms, float accel_cmss)
     const float snap_max_cmssss = MIN(_attitude_control.get_accel_roll_max_radss(), _attitude_control.get_accel_pitch_max_radss()) * GRAVITY_MSS * 100.0;
 
     // get specified jerk limit
-    _jerk_max_xy_cmsss = _shaping_jerk_xy * 100.0;
+    _jerk_max_xy_cmsss = get_shaping_jerk_xy_cmsss();
 
     // limit maximum jerk based on maximum angular rate
     if (is_positive(jerk_max_cmsss) && _attitude_control.get_bf_feedforward()) {

--- a/libraries/AC_AttitudeControl/AC_PosControl.h
+++ b/libraries/AC_AttitudeControl/AC_PosControl.h
@@ -71,7 +71,7 @@ public:
     ///     by the kinematic shaping.
     void set_max_speed_accel_xy(float speed_cms, float accel_cmss);
 
-    /// set_max_speed_accel_xy - set the position controller correction velocity and acceleration limit
+    /// set_correction_speed_accel_xy - set the position controller correction velocity and acceleration limit
     ///     This should be done only during initialisation to avoid discontinuities
     void set_correction_speed_accel_xy(float speed_cms, float accel_cmss);
 


### PR DESCRIPTION
Use the shared `get_shaping_jerk_xy_cmsss` function in `AC_PosControl` instead of redefining the value in the same manner.