### PR TITLE
[NHW] Add RTL_ACCEL behaviour

### DIFF
--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -165,6 +165,15 @@ const AP_Param::Info Copter::var_info[] = {
     // @Values: 0:Relative to Home, 1:Terrain
     // @User: Standard
     GSCALAR(rtl_alt_type, "RTL_ALT_TYPE", 0),
+
+    // @Param: RTL_ACCEL
+    // @DisplayName: RTL acceleration
+    // @Description: Acceleration target in cm/s/s that RTL will attempt to slow the aircraft during the initial brake. Set to 0 to use WPNAV_ACCEL
+    // @Units: cm/s/s
+    // @Range: 0 10000
+    // @Increment: 100
+    // @User: Advanced
+    GSCALAR(rtl_accel_cmss,      "RTL_ACCEL",    RTL_ACCEL),
 #endif
 
     // @Param: FS_GCS_ENABLE

--- a/ArduCopter/Parameters.cpp
+++ b/ArduCopter/Parameters.cpp
@@ -170,8 +170,8 @@ const AP_Param::Info Copter::var_info[] = {
     // @DisplayName: RTL acceleration
     // @Description: Acceleration target in cm/s/s that RTL will attempt to slow the aircraft during the initial brake. Set to 0 to use WPNAV_ACCEL
     // @Units: cm/s/s
-    // @Range: 0 10000
-    // @Increment: 100
+    // @Range: 0 1000
+    // @Increment: 10
     // @User: Advanced
     GSCALAR(rtl_accel_cmss,      "RTL_ACCEL",    RTL_ACCEL),
 #endif

--- a/ArduCopter/Parameters.h
+++ b/ArduCopter/Parameters.h
@@ -230,6 +230,7 @@ public:
         k_param_rtl_speed_cms = 135,
         k_param_fs_batt_curr_rtl,
         k_param_rtl_cone_slope, // 137
+        k_param_rtl_accel_cmss,
 
         //
         // 140: Sensor parameters
@@ -402,6 +403,7 @@ public:
     AP_Int16        rtl_climb_min;              // rtl minimum climb in cm
     AP_Int32        rtl_loiter_time;
     AP_Int8         rtl_alt_type;
+    AP_Int32        rtl_accel_cmss;
 #endif
 
     AP_Int8         failsafe_gcs;               // ground station failsafe behavior

--- a/ArduCopter/config.h
+++ b/ArduCopter/config.h
@@ -517,6 +517,10 @@
  # define RTL_LOITER_TIME           5000    // Time (in milliseconds) to loiter above home before beginning final descent
 #endif
 
+#ifndef RTL_ACCEL
+ # define RTL_ACCEL                 0       // Acceleration in cm/s/s used during initial braking for RTL. Value of 0 uses WPNAV_ACCEL
+#endif
+
 // AUTO Mode
 #ifndef WP_YAW_BEHAVIOR_DEFAULT
  # define WP_YAW_BEHAVIOR_DEFAULT   WP_YAW_BEHAVIOR_LOOK_AT_NEXT_WP_EXCEPT_RTL

--- a/ArduCopter/mode_rtl.cpp
+++ b/ArduCopter/mode_rtl.cpp
@@ -175,12 +175,13 @@ void ModeRTL::brake_run()
     pos_control->set_pos_target_z_from_climb_rate_cm(0.0f);
     pos_control->update_z_controller();
 
-    if (inertial_nav.get_velocity_neu_cms().length() < g.rtl_speed_cms && g.rtl_speed_cms != 0) {
+    // Modified to check that we're braking down slow enough rather than to RTL speed
+    if (inertial_nav.get_velocity_neu_cms().length() < 100 && g.rtl_speed_cms != 0) {
         _state_complete = true;
         _state = SubMode::STARTING;
         //undo the changes we made to the vel targets. 
         wp_nav->set_speed_xy(g.rtl_speed_cms); 
-    } else if (inertial_nav.get_velocity_neu_cms().length() < wp_nav->get_default_speed_xy() && g.rtl_speed_cms == 0) {
+    } else if (inertial_nav.get_velocity_neu_cms().length() < 100 && g.rtl_speed_cms == 0) {
         _state_complete = true;
         _state = SubMode::STARTING;
         wp_nav->set_speed_xy(wp_nav->get_default_speed_xy()); // reset the velocity to wpnav_speed
@@ -468,6 +469,13 @@ void ModeRTL::brake_init()
 {
     _state = SubMode::BRAKING;
     float accel_max = wp_nav->get_wp_acceleration(); // [NHW] Get WPNAV_ACCEL parameter for braking acceleration
+    if (g.rtl_accel_cmss > 0){         // Use RTL_ACCEL if not set to 0
+        accel_max = g.rtl_accel_cmss;
+        if (accel_max > 1000){         // Sanity check limit to 10m/s/s - note for rediculous power to weight FPV types, this may be conservative.
+            accel_max = 1000;
+        }
+    }
+    
     float z_speed = wp_nav->get_default_speed_down(); // [NHW} get default vertical speed. Use descent only for safety.
     // initialise pos controller speed and acceleration
     pos_control->set_max_speed_accel_xy(inertial_nav.get_velocity_neu_cms().length(), accel_max);

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -8,11 +8,7 @@
 
 
 
-<<<<<<< HEAD
-#define THISFIRMWARE "MA_Copter-V4.3.0.11_DEV_.2"
-=======
 #define THISFIRMWARE "MA_COPTER-V4.3.0.12_DEV.2"
->>>>>>> e33f86d6de... [NHW] Capitilisation typo
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -8,7 +8,11 @@
 
 
 
+<<<<<<< HEAD
 #define THISFIRMWARE "MA_Copter-V4.3.0.11_DEV_.2"
+=======
+#define THISFIRMWARE "MA_COPTER-V4.3.0.12_DEV.2"
+>>>>>>> e33f86d6de... [NHW] Capitilisation typo
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -8,7 +8,11 @@
 
 
 
+<<<<<<< HEAD
 #define THISFIRMWARE "MA_COPTER-V4.3.0.12-DEV-I2C"
+=======
+#define THISFIRMWARE "MA_Copter-V4.3.0.11_DEV_RTLACCEL"
+>>>>>>> 50cf730d6e... [NHW] Add RTL_ACCEL param
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -8,11 +8,7 @@
 
 
 
-<<<<<<< HEAD
-#define THISFIRMWARE "MA_COPTER-V4.3.0.12-DEV-I2C"
-=======
-#define THISFIRMWARE "MA_Copter-V4.3.0.11_DEV_RTLACCEL"
->>>>>>> 50cf730d6e... [NHW] Add RTL_ACCEL param
+#define THISFIRMWARE "MA_Copter-V4.3.0.11_DEV_.2"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4,3,0,FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -9085,7 +9085,7 @@ class AutoTestCopter(AutoTest):
         self.progress(f"RTL braking distance: {actual_distance:.2f}m")
         self.progress(f"Expected braking distance: {expected_distance:.2f}m")
         
-        tolerance = 10
+        tolerance = 20 # Tolerance for the braking distance in m.
         
         if abs(actual_distance - expected_distance) > tolerance:
             raise NotAchievedException(

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8936,24 +8936,14 @@ class AutoTestCopter(AutoTest):
             expected_distance=49.7,
         )
         self.reboot_sitl()
-        
-        self.start_subtest('RTL braking from 20m/s with wp_accel of 9.81m/s/s and psc jerk limit of 5m/s/s/s')
+         
+        self.start_subtest('RTL braking from 20m/s with wp_accel of 5m/s/s and psc jerk limit of 2m/s/s/s')
         self.test_rtl_braking_case(
             wpnav_speed=20,
-            wpnav_accel=9.81,
-            psc_jerk_xy=5,
-            rtl_accel=0,
-            expected_distance=40,
-        )
-        self.reboot_sitl()
-               
-        self.start_subtest('RTL braking from 20m/s with wp_accel of 9.81m/s/s and psc jerk limit of 2m/s/s/s')
-        self.test_rtl_braking_case(
-            wpnav_speed=20,
-            wpnav_accel=9.81,
+            wpnav_accel=5,
             psc_jerk_xy=2,
             rtl_accel=0,
-            expected_distance=89.4,
+            expected_distance=65,
         )
         self.reboot_sitl()
 
@@ -8974,26 +8964,6 @@ class AutoTestCopter(AutoTest):
             psc_jerk_xy=5,
             rtl_accel=5,
             expected_distance=50,
-        )
-        self.reboot_sitl()
-
-        self.start_subtest('RTL braking from 20m/s with rtl_accel of 10/s/s and psc jerk limit of 5m/s/s/s')
-        self.test_rtl_braking_case(
-            wpnav_speed=20,
-            wpnav_accel=3,
-            psc_jerk_xy=5,
-            rtl_accel=10,
-            expected_distance=40,
-        )
-        self.reboot_sitl()
-
-        self.start_subtest('RTL braking from 20m/s with rtl_accel of 15/s/s and psc jerk limit of 5m/s/s/s')
-        self.test_rtl_braking_case(
-            wpnav_speed=20,
-            wpnav_accel=3,
-            psc_jerk_xy=5,
-            rtl_accel=10,       # Check the sanity limit is working
-            expected_distance=40,
         )
         self.reboot_sitl()
 

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8907,52 +8907,101 @@ class AutoTestCopter(AutoTest):
         # Expected braking distance is calculated based on jerk-limited s-curve braking profile
         # Use the calculate_rtl_braking_distance.py script to calculate expected distances.
         
-        self.start_subtest('RTL braking from 20m/s with accel of 2.5m/s/s and jerk of 5m/s/s/s')
+        self.start_subtest('RTL braking from 20m/s with wp_accel of 2.5m/s/s and jerk of 5m/s/s/s')
         self.test_rtl_braking_case(
             wpnav_speed=20,
             wpnav_accel=2.5,
             psc_jerk_xy=5,
+            rtl_accel=0,
             expected_distance=85,
         )
         self.reboot_sitl()
         
-        self.start_subtest('RTL braking from 20m/s with accel of 5m/s/s and psc jerk limit of 5m/s/s/s')
+        self.start_subtest('RTL braking from 20m/s with wp_accel of 5m/s/s and psc jerk limit of 5m/s/s/s')
         self.test_rtl_braking_case(
             wpnav_speed=20,
             wpnav_accel=5,
             psc_jerk_xy=5,
+            rtl_accel=0,
             expected_distance=50,
         )
         self.reboot_sitl()
         
-        self.start_subtest('RTL braking from 20m/s with accel of 5m/s/s and psc jerk limit of 20m/s/s/s')
+        self.start_subtest('RTL braking from 20m/s with wp_accel of 5m/s/s and psc jerk limit of 20m/s/s/s')
         self.test_rtl_braking_case(
             wpnav_speed=20,
             wpnav_accel=5,
             psc_jerk_xy=20,
+            rtl_accel=0,
             expected_distance=49.7,
         )
         self.reboot_sitl()
         
-        self.start_subtest('RTL braking from 20m/s with accel of 9.81m/s/s and psc jerk limit of 5m/s/s/s')
+        self.start_subtest('RTL braking from 20m/s with wp_accel of 9.81m/s/s and psc jerk limit of 5m/s/s/s')
         self.test_rtl_braking_case(
             wpnav_speed=20,
             wpnav_accel=9.81,
             psc_jerk_xy=5,
+            rtl_accel=0,
             expected_distance=40,
         )
         self.reboot_sitl()
                
-        # For some reason the actual distance comes out to be 137.8m, which doesn't make sense to me...
-        # self.start_subtest('RTL braking from 20m/s with accel of 9.81m/s/s and psc jerk limit of 2m/s/s/s')
-        # self.test_rtl_braking_case(
-        #     wpnav_speed=20,
-        #     wpnav_accel=9.81,
-        #     psc_jerk_xy=1,
-        #     expected_distance=89.4,
-        # )
+        self.start_subtest('RTL braking from 20m/s with wp_accel of 9.81m/s/s and psc jerk limit of 2m/s/s/s')
+        self.test_rtl_braking_case(
+            wpnav_speed=20,
+            wpnav_accel=9.81,
+            psc_jerk_xy=2,
+            rtl_accel=0,
+            expected_distance=89.4,
+        )
         
-    def test_rtl_braking_case(self, wpnav_speed, wpnav_accel, psc_jerk_xy, expected_distance):
+        self.start_subtest('RTL braking from 20m/s with rtl_accel of 1/s/s and psc jerk limit of 5m/s/s/s')
+        self.test_rtl_braking_case(
+            wpnav_speed=20,
+            wpnav_accel=3,
+            psc_jerk_xy=5,
+            rtl_accel=1,
+            expected_distance=202,
+        )
+
+        self.start_subtest('RTL braking from 20m/s with rtl_accel of 5/s/s and psc jerk limit of 5m/s/s/s')
+        self.test_rtl_braking_case(
+            wpnav_speed=20,
+            wpnav_accel=3,
+            psc_jerk_xy=5,
+            rtl_accel=5,
+            expected_distance=50,
+        )
+
+        self.start_subtest('RTL braking from 20m/s with rtl_accel of 10/s/s and psc jerk limit of 5m/s/s/s')
+        self.test_rtl_braking_case(
+            wpnav_speed=20,
+            wpnav_accel=3,
+            psc_jerk_xy=5,
+            rtl_accel=10,
+            expected_distance=40,
+        )
+
+        self.start_subtest('RTL braking from 20m/s with rtl_accel of 15/s/s and psc jerk limit of 5m/s/s/s')
+        self.test_rtl_braking_case(
+            wpnav_speed=20,
+            wpnav_accel=3,
+            psc_jerk_xy=5,
+            rtl_accel=10,       # Check the sanity limit is working
+            expected_distance=40,
+        )
+
+        self.start_subtest('RTL braking from 20m/s with rtl_accel of -1/s/s and psc jerk limit of 5m/s/s/s')
+        self.test_rtl_braking_case(
+            wpnav_speed=20,
+            wpnav_accel=3,
+            psc_jerk_xy=5,
+            rtl_accel=-1,
+            expected_distance=72.7,
+        )
+
+    def test_rtl_braking_case(self, wpnav_speed, wpnav_accel, psc_jerk_xy, rtl_accel, expected_distance):
         '''Helper method to test RTL braking distance for a specific configuration'''
         self.context_push()
         
@@ -8967,6 +9016,7 @@ class AutoTestCopter(AutoTest):
             'RTL_ALT': alt * 100,
             'RTL_SPEED': 300,
             'PSC_JERK_XY': psc_jerk_xy,
+            'RTL_ACCEL': rtl_accel * 100,
         })
 
         self.takeoff(alt_min=alt, mode='GUIDED')

--- a/Tools/autotest/arducopter.py
+++ b/Tools/autotest/arducopter.py
@@ -8955,7 +8955,8 @@ class AutoTestCopter(AutoTest):
             rtl_accel=0,
             expected_distance=89.4,
         )
-        
+        self.reboot_sitl()
+
         self.start_subtest('RTL braking from 20m/s with rtl_accel of 1/s/s and psc jerk limit of 5m/s/s/s')
         self.test_rtl_braking_case(
             wpnav_speed=20,
@@ -8964,6 +8965,7 @@ class AutoTestCopter(AutoTest):
             rtl_accel=1,
             expected_distance=202,
         )
+        self.reboot_sitl()
 
         self.start_subtest('RTL braking from 20m/s with rtl_accel of 5/s/s and psc jerk limit of 5m/s/s/s')
         self.test_rtl_braking_case(
@@ -8973,6 +8975,7 @@ class AutoTestCopter(AutoTest):
             rtl_accel=5,
             expected_distance=50,
         )
+        self.reboot_sitl()
 
         self.start_subtest('RTL braking from 20m/s with rtl_accel of 10/s/s and psc jerk limit of 5m/s/s/s')
         self.test_rtl_braking_case(
@@ -8982,6 +8985,7 @@ class AutoTestCopter(AutoTest):
             rtl_accel=10,
             expected_distance=40,
         )
+        self.reboot_sitl()
 
         self.start_subtest('RTL braking from 20m/s with rtl_accel of 15/s/s and psc jerk limit of 5m/s/s/s')
         self.test_rtl_braking_case(
@@ -8991,6 +8995,7 @@ class AutoTestCopter(AutoTest):
             rtl_accel=10,       # Check the sanity limit is working
             expected_distance=40,
         )
+        self.reboot_sitl()
 
         self.start_subtest('RTL braking from 20m/s with rtl_accel of -1/s/s and psc jerk limit of 5m/s/s/s')
         self.test_rtl_braking_case(
@@ -9000,7 +9005,8 @@ class AutoTestCopter(AutoTest):
             rtl_accel=-1,
             expected_distance=72.7,
         )
-
+        self.reboot_sitl()
+        
     def test_rtl_braking_case(self, wpnav_speed, wpnav_accel, psc_jerk_xy, rtl_accel, expected_distance):
         '''Helper method to test RTL braking distance for a specific configuration'''
         self.context_push()

--- a/Tools/scripts/calculate_rtl_braking_distance.py
+++ b/Tools/scripts/calculate_rtl_braking_distance.py
@@ -82,6 +82,12 @@ rate_p_max_deg = 30
 accel_r_max_cdegss = 110_000
 accel_p_max_cdegss = 110_000
 rate_ff_enabled = True
+rtl_accel = 0
+
+if (rtl_accel <= 0):        # Check for valid rtl_accel
+    wpnav_accel_mss = rtl_accel
+    if (wpnav_accel_mss > 10):  # Cap if at 10 if using it
+        wpnav_accel_mss = 10
 
 # Get max jerk rate (AC_PosControl::set_max_speed_accel_xy)
 


### PR DESCRIPTION
Added in RTL_ACCEL param to modify the initial braking behavior of RTL mode.

Now also brakes down manually until 1m/s before handing back to the OG RTL controller.

RTL_ACCEL is sense checked between 0 and 1000 cm/s/s, A value of 0 will default back to using WPNAV_ACCEL. Default param set to 0, inline with original AP design intent.

Also updated the version number to a numeric system for DEV work. Suggest this is used as current main now has multiple dev items included. Number could be excluded, but could make it tricky to track which version is in use on hardware, so suggest keeping it.

This is the second version of the PR after the disaster that was the history first time around. 