### PR TITLE
CAN Driver for the Gripper

### DIFF
--- a/libraries/AP_Gripper/AP_Gripper.cpp
+++ b/libraries/AP_Gripper/AP_Gripper.cpp
@@ -1,6 +1,7 @@
 #include "AP_Gripper.h"
 
 #include "AP_Gripper_Servo.h"
+#include "AP_Gripper_CAN.h"
 #include "AP_Gripper_EPM.h"
 
 extern const AP_HAL::HAL& hal;
@@ -24,7 +25,7 @@ const AP_Param::GroupInfo AP_Gripper::var_info[] = {
     // @DisplayName: Gripper Type
     // @Description: Gripper enable/disable
     // @User: Standard
-    // @Values: 0:None,1:Servo,2:EPM
+    // @Values: 0:None,1:Servo,2:EPM,3:CAN
     AP_GROUPINFO("TYPE", 1, AP_Gripper, config.type, 0),
 
     // @Param: GRAB
@@ -114,6 +115,9 @@ void AP_Gripper::init()
         break;
     case 2:
         backend = new AP_Gripper_EPM(config);
+        break;
+    case 3:
+        backend = new AP_Gripper_CAN(config);
         break;
     default:
         break;

--- a/libraries/AP_Gripper/AP_Gripper_CAN.cpp
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.cpp
@@ -56,7 +56,8 @@ void AP_Gripper_CAN::grab()
     // Send position command to close gripper
     if (send_position_command(POS_MAX)) {
         _state_changed = true;
-        // action_timestamp = AP_HAL::millis();
+        // Log the grab event. Please note Drop Mech has reverse logic than Gripper where grab is actually the open dropmech command
+        AP::logger().Write_Event(LogEvent::GRIPPER_GRAB);
     }
     
 }
@@ -71,7 +72,8 @@ void AP_Gripper_CAN::release()
     // Typically, open = low position value
     if (send_position_command(POS_MIN)) {
         _state_changed = true;
-        // action_timestamp = AP_HAL::millis();
+        // Log the release event. Please note Drop Mech has reverse logic than Gripper where release is actually the close dropmech command
+        AP::logger().Write_Event(LogEvent::GRIPPER_RELEASE);
     }
 }
 

--- a/libraries/AP_Gripper/AP_Gripper_CAN.cpp
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.cpp
@@ -24,10 +24,7 @@ AP_Gripper_CAN::AP_Gripper_CAN(struct AP_Gripper::Backend_Config &_config) :
     _last_send_ms = 0;
     _sequence_num = 0;
     _current_position = 0;
-    _last_rc_input = RC_MID;
     _armed = false;
-    // _board_id = 4;
-    // CAN message ID to all boards
     _can_msg_id = 0x320;
 }
 
@@ -169,6 +166,7 @@ bool AP_Gripper_CAN::send_position_command(uint8_t position)
     
     AP_HAL::CANFrame frame0, frame1;
     build_position_frames(position, frame0, frame1);
+    // Debug Code to print frames before sending
     // print_frame(frame0);
     // print_frame(frame1);
     

--- a/libraries/AP_Gripper/AP_Gripper_CAN.cpp
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.cpp
@@ -53,15 +53,11 @@ void AP_Gripper_CAN::grab()
 {
     // Send position command to close gripper
     // Typically, close = high position value
-    // First ARM the gripper if not already armed
-    if (!_armed) {
-        send_arm_command(true);
-        _armed = true;
-    }
+    // ARM the System
+    send_arm_command(true);
     
     // Send position command to close gripper
-    // Typically, close = high position value
-    if (send_position_command(POS_MIN)) {
+    if (send_position_command(POS_MAX)) {
         _state_changed = true;
         // action_timestamp = AP_HAL::millis();
     }
@@ -72,14 +68,11 @@ void AP_Gripper_CAN::grab()
 void AP_Gripper_CAN::release()
 {
     // First ARM the gripper if not already armed
-    if (!_armed) {
-        send_arm_command(true);
-        _armed = true;
-    }
-    
+    send_arm_command(true);
+
     // Send position command to open gripper
     // Typically, open = low position value
-    if (send_position_command(POS_MAX)) {
+    if (send_position_command(POS_MIN)) {
         _state_changed = true;
         // action_timestamp = AP_HAL::millis();
     }

--- a/libraries/AP_Gripper/AP_Gripper_CAN.cpp
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.cpp
@@ -27,7 +27,7 @@ AP_Gripper_CAN::AP_Gripper_CAN(struct AP_Gripper::Backend_Config &_config) :
     _last_rc_input = RC_MID;
     _armed = false;
     // _board_id = 4;
-    // Calculate CAN message ID
+    // CAN message ID to all boards
     _can_msg_id = 0x320;
 }
 
@@ -61,7 +61,7 @@ void AP_Gripper_CAN::grab()
     
     // Send position command to close gripper
     // Typically, close = high position value
-    if (send_position_command(POS_MAX)) {
+    if (send_position_command(POS_MIN)) {
         _state_changed = true;
         // action_timestamp = AP_HAL::millis();
     }
@@ -79,7 +79,7 @@ void AP_Gripper_CAN::release()
     
     // Send position command to open gripper
     // Typically, open = low position value
-    if (send_position_command(POS_MIN)) {
+    if (send_position_command(POS_MAX)) {
         _state_changed = true;
         // action_timestamp = AP_HAL::millis();
     }
@@ -130,11 +130,13 @@ void AP_Gripper_CAN::build_arm_frame(bool arm, AP_HAL::CANFrame& frame)
     frame.data[7] = 0x00;
 }
 
+// Utility function to print CAN frame (for debugging)
 void print_frame(const AP_HAL::CANFrame& frame)
 {
     hal.console->printf("CAN ID: 0x%03X DLC: %u Data:", static_cast<unsigned int>(frame.id), frame.dlc);
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "CAN ID: %03X DLC: %u Data:", static_cast<unsigned int>(frame.id), frame.dlc);
     for (uint8_t i = 0; i < frame.dlc; i++) {
+        
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, " %02X", frame.data[i]);
     }
     hal.console->printf("\n");
@@ -174,8 +176,8 @@ bool AP_Gripper_CAN::send_position_command(uint8_t position)
     
     AP_HAL::CANFrame frame0, frame1;
     build_position_frames(position, frame0, frame1);
-    print_frame(frame0);
-    print_frame(frame1);
+    // print_frame(frame0);
+    // print_frame(frame1);
     
     // Send trunk 0
     uint64_t timeout = AP_HAL::micros64() + GRIPPER_CAN_TIMEOUT_MS * 1000ULL;
@@ -260,23 +262,6 @@ void AP_Gripper_CAN::build_position_frames(uint8_t position, AP_HAL::CANFrame& f
     // Bytes 6-7: Reserved (0x0)
     frame1.data[6] = 0x00;
     frame1.data[7] = 0x00;
-}
-
-// Convert RC input (1000-2000) to position command (1-255)
-uint8_t AP_Gripper_CAN::rc_to_position(uint16_t rc_value)
-{
-    // Constrain input
-    rc_value = constrain_int16(rc_value, RC_MIN, RC_MAX);
-    
-    // Map RC range (1000-2000) to position range (1-255)
-    // Linear interpolation
-    // int32_t position = ((int32_t)(rc_value - RC_MIN) * (POS_MAX - POS_MIN)) / (RC_MAX - RC_MIN) + POS_MIN;
-    if( rc_value <= RC_MIN) {
-        return POS_MIN;
-    } else if (rc_value >= RC_MAX) {
-        return POS_MAX;
-    } 
-    return POS_NEUTRAL;
 }
 
 // #endif  // AP_GRIPPER_ENABLED

--- a/libraries/AP_Gripper/AP_Gripper_CAN.cpp
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.cpp
@@ -18,7 +18,6 @@ extern const AP_HAL::HAL& hal;
 AP_Gripper_CAN::AP_Gripper_CAN(struct AP_Gripper::Backend_Config &_config) :
     AP_Gripper_Backend(_config)  // Default board_ID, should be configurable via parameter
 {
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper CAN backend constructor");
     _can_iface = nullptr;
     _can_driver_index = 0;  // CAN peripheral driver 1
     _state_changed = false;
@@ -40,18 +39,13 @@ void AP_Gripper_CAN::init_gripper()
     _can_iface = hal.can[_can_driver_index];
     
     if (_can_iface == nullptr) {
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Failed to get CAN interface %u\n", _can_driver_index);
         return;
     }
     
     // Initialize the CAN interface if not already initialized
     if (!_can_iface->is_initialized()) {
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: CAN interface %u not initialized\n", _can_driver_index);
         return;
     }
-    
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Initialized on CAN%u, Msg ID: 0x%03X\n", 
-                       _can_driver_index + 1, _can_msg_id);
 }
 
 // Grab - close the gripper (set to maximum position)
@@ -61,7 +55,6 @@ void AP_Gripper_CAN::grab()
     // Typically, close = high position value
     // First ARM the gripper if not already armed
     if (!_armed) {
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SEND ARM COMMAND");
         send_arm_command(true);
         _armed = true;
     }
@@ -102,7 +95,7 @@ bool AP_Gripper_CAN::valid() const
 // Update gripper - called regularly from main loop
 void AP_Gripper_CAN::update_gripper()
 {
-    // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper CAN update not implemented yet");
+    // No implementation needed for now
 }
 
 // Build ARM state CAN frame (Message 1: 1 trunk)
@@ -139,12 +132,12 @@ void AP_Gripper_CAN::build_arm_frame(bool arm, AP_HAL::CANFrame& frame)
 
 void print_frame(const AP_HAL::CANFrame& frame)
 {
-    // hal.console->printf("CAN ID: 0x%03X DLC: %u Data:", static_cast<unsigned int>(frame.id), frame.dlc);
+    hal.console->printf("CAN ID: 0x%03X DLC: %u Data:", static_cast<unsigned int>(frame.id), frame.dlc);
     GCS_SEND_TEXT(MAV_SEVERITY_INFO, "CAN ID: %03X DLC: %u Data:", static_cast<unsigned int>(frame.id), frame.dlc);
     for (uint8_t i = 0; i < frame.dlc; i++) {
         GCS_SEND_TEXT(MAV_SEVERITY_INFO, " %02X", frame.data[i]);
     }
-    // hal.console->printf("\n");
+    hal.console->printf("\n");
 }
 
 // Send ARM/DISARM command (Message 1)
@@ -160,8 +153,7 @@ bool AP_Gripper_CAN::send_arm_command(bool arm)
     // Send the frame
     uint64_t timeout = AP_HAL::micros64() + GRIPPER_CAN_TIMEOUT_MS * 1000ULL;
     int16_t res = _can_iface->send(frame, timeout, 0);
-    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Sent ARM command, arm=%d", arm);
-    
+
     if (res <= 0) {
         hal.console->printf("Gripper_CAN: Failed to send ARM command, res=%d\n", res);
         return false;
@@ -190,7 +182,6 @@ bool AP_Gripper_CAN::send_position_command(uint8_t position)
     int16_t res = _can_iface->send(frame0, timeout, 0);
     
     if (res <= 0) {
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Failed to send position trunk 0, res=%d\n", res);
         return false;
     }
     
@@ -199,7 +190,6 @@ bool AP_Gripper_CAN::send_position_command(uint8_t position)
     res = _can_iface->send(frame1, timeout, 0);
     
     if (res <= 0) {
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Failed to send position trunk 1, res=%d\n", res);
         return false;
     }
     

--- a/libraries/AP_Gripper/AP_Gripper_CAN.cpp
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.cpp
@@ -1,0 +1,292 @@
+/*
+ * AP_Gripper_CAN.cpp
+ *
+ * CAN-based gripper driver implementation
+ */
+
+#include "AP_Gripper_CAN.h"
+
+// #if AP_GRIPPER_ENABLED
+
+#include <AP_HAL/AP_HAL.h>
+#include <AP_Logger/AP_Logger.h>
+#include <RC_Channel/RC_Channel.h>
+
+extern const AP_HAL::HAL& hal;
+
+// Constructor
+AP_Gripper_CAN::AP_Gripper_CAN(struct AP_Gripper::Backend_Config &_config) :
+    AP_Gripper_Backend(_config)  // Default board_ID, should be configurable via parameter
+{
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper CAN backend constructor");
+    _can_iface = nullptr;
+    _can_driver_index = 0;  // CAN peripheral driver 1
+    _state_changed = false;
+    _last_send_ms = 0;
+    _sequence_num = 0;
+    _current_position = 0;
+    _last_rc_input = RC_MID;
+    _armed = false;
+    // _board_id = 4;
+    // Calculate CAN message ID
+    _can_msg_id = 0x320;
+}
+
+// Initialize the CAN gripper
+void AP_Gripper_CAN::init_gripper()
+{
+    // Get CAN interface directly from HAL
+    // _can_driver_index represents which physical CAN peripheral to use (0=CAN1, 1=CAN2)
+    _can_iface = hal.can[_can_driver_index];
+    
+    if (_can_iface == nullptr) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Failed to get CAN interface %u\n", _can_driver_index);
+        return;
+    }
+    
+    // Initialize the CAN interface if not already initialized
+    if (!_can_iface->is_initialized()) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: CAN interface %u not initialized\n", _can_driver_index);
+        return;
+    }
+    
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Initialized on CAN%u, Msg ID: 0x%03X\n", 
+                       _can_driver_index + 1, _can_msg_id);
+}
+
+// Grab - close the gripper (set to maximum position)
+void AP_Gripper_CAN::grab()
+{
+    // Send position command to close gripper
+    // Typically, close = high position value
+    // First ARM the gripper if not already armed
+    if (!_armed) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "SEND ARM COMMAND");
+        send_arm_command(true);
+        _armed = true;
+    }
+    
+    // Send position command to close gripper
+    // Typically, close = high position value
+    if (send_position_command(POS_MAX)) {
+        _state_changed = true;
+        // action_timestamp = AP_HAL::millis();
+    }
+    
+}
+
+// Release - open the gripper (set to minimum position)
+void AP_Gripper_CAN::release()
+{
+    // First ARM the gripper if not already armed
+    if (!_armed) {
+        send_arm_command(true);
+        _armed = true;
+    }
+    
+    // Send position command to open gripper
+    // Typically, open = low position value
+    if (send_position_command(POS_MIN)) {
+        _state_changed = true;
+        // action_timestamp = AP_HAL::millis();
+    }
+}
+
+// Check if gripper is healthy
+bool AP_Gripper_CAN::valid() const
+{
+    return (_can_iface != nullptr);
+    // return true;
+}
+
+// Update gripper - called regularly from main loop
+void AP_Gripper_CAN::update_gripper()
+{
+    // GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper CAN update not implemented yet");
+}
+
+// Build ARM state CAN frame (Message 1: 1 trunk)
+void AP_Gripper_CAN::build_arm_frame(bool arm, AP_HAL::CANFrame& frame)
+{
+    frame.id = _can_msg_id;  // 0x320 + board_ID
+    frame.dlc = 8;
+    
+    // Byte 0: Sequence number (bits 6-7) and Total trunks (bits 0-5)
+    // Bits 6-7: sequence (0-3)
+    // Bits 0-5: total_trunks = 1
+    frame.data[0] = ((_sequence_num & 0x03) << 6) | (1 & 0x3F);
+    
+    // Byte 1: 0x0 (bits 6-7) and Message trunk number (bits 0-5)
+    // Bits 6-7: 0x0
+    // Bits 0-5: trunk_num = 0
+    frame.data[1] = (0 << 6) | (0 & 0x3F);
+    
+    // Bytes 2-5: Reserved (0x0)
+    frame.data[2] = 0x00;
+    frame.data[3] = 0x00;
+    frame.data[4] = 0x00;
+    frame.data[5] = 0x00;
+    
+    // Byte 6: ARM state
+    // Bits 0-3: MCU-CAN state (ignored if from FC-CAN) - set to 0
+    // Bits 4-7: FC-CAN state: 1=standby(disarm), 2=arm
+    uint8_t fc_state = arm ? 2 : 1;  // 2=arm, 1=disarm
+    frame.data[6] = (fc_state << 4) | 0;  // FC state in upper nibble
+    
+    // Byte 7: Reserved (0x0)
+    frame.data[7] = 0x00;
+}
+
+void print_frame(const AP_HAL::CANFrame& frame)
+{
+    // hal.console->printf("CAN ID: 0x%03X DLC: %u Data:", static_cast<unsigned int>(frame.id), frame.dlc);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "CAN ID: %03X DLC: %u Data:", static_cast<unsigned int>(frame.id), frame.dlc);
+    for (uint8_t i = 0; i < frame.dlc; i++) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, " %02X", frame.data[i]);
+    }
+    // hal.console->printf("\n");
+}
+
+// Send ARM/DISARM command (Message 1)
+bool AP_Gripper_CAN::send_arm_command(bool arm)
+{
+    if (_can_iface == nullptr) {
+        return false;
+    }
+    
+    AP_HAL::CANFrame frame;
+    build_arm_frame(arm, frame);
+    
+    // Send the frame
+    uint64_t timeout = AP_HAL::micros64() + GRIPPER_CAN_TIMEOUT_MS * 1000ULL;
+    int16_t res = _can_iface->send(frame, timeout, 0);
+    GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Sent ARM command, arm=%d", arm);
+    
+    if (res <= 0) {
+        hal.console->printf("Gripper_CAN: Failed to send ARM command, res=%d\n", res);
+        return false;
+    }
+    
+    // Increment sequence number (wraps at 4)
+    _sequence_num = (_sequence_num + 1) & 0x03;
+    
+    return true;
+}
+
+// Send position command (Message 2: 2 trunks)
+bool AP_Gripper_CAN::send_position_command(uint8_t position)
+{
+    if (_can_iface == nullptr) {
+        return false;
+    }
+    
+    AP_HAL::CANFrame frame0, frame1;
+    build_position_frames(position, frame0, frame1);
+    print_frame(frame0);
+    print_frame(frame1);
+    
+    // Send trunk 0
+    uint64_t timeout = AP_HAL::micros64() + GRIPPER_CAN_TIMEOUT_MS * 1000ULL;
+    int16_t res = _can_iface->send(frame0, timeout, 0);
+    
+    if (res <= 0) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Failed to send position trunk 0, res=%d\n", res);
+        return false;
+    }
+    
+    // Send trunk 1
+    timeout = AP_HAL::micros64() + GRIPPER_CAN_TIMEOUT_MS * 1000ULL;
+    res = _can_iface->send(frame1, timeout, 0);
+    
+    if (res <= 0) {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper_CAN: Failed to send position trunk 1, res=%d\n", res);
+        return false;
+    }
+    
+    // Increment sequence number (wraps at 4)
+    _sequence_num = (_sequence_num + 1) & 0x03;
+    _current_position = position;
+    _last_send_ms = AP_HAL::millis();
+    
+    return true;
+}
+
+
+
+// Build position control CAN frames (Message 2: 2 trunks)
+void AP_Gripper_CAN::build_position_frames(uint8_t position, AP_HAL::CANFrame& frame0, AP_HAL::CANFrame& frame1)
+{
+    // Get 64-bit timestamp (microseconds or milliseconds depending on your needs)
+    // The spec shows 8 bytes split: Byte0-3 in trunk0, Byte4-7 in trunk1
+    // uint64_t timestamp = AP_HAL::micros64();
+    uint64_t timestamp = 0;
+    
+    // === TRUNK 0 (Message trunk number 0) ===
+    frame0.id = _can_msg_id;  // 0x320 + board_ID
+    frame0.dlc = 8;
+    
+    // Byte 0: Sequence number (bits 6-7) and Total trunks (bits 0-5)
+    // Bits 6-7: sequence (0-3)
+    // Bits 0-5: total_trunks = 2
+    frame0.data[0] = ((_sequence_num & 0x03) << 6) | (2 & 0x3F);
+    
+    // Byte 1: 0x0 (bits 6-7) and Message trunk number (bits 0-5)
+    // Bits 6-7: 0x0
+    // Bits 0-5: trunk_num = 0
+    frame0.data[1] = (0 << 6) | (0 & 0x3F);
+    
+    // Bytes 2-5: Command execution timestamp (little-endian, Byte0-3)
+    frame0.data[2] = (timestamp >> 0) & 0xFF;   // Byte 0 of timestamp
+    frame0.data[3] = (timestamp >> 8) & 0xFF;   // Byte 1 of timestamp
+    frame0.data[4] = (timestamp >> 16) & 0xFF;  // Byte 2 of timestamp
+    frame0.data[5] = (timestamp >> 24) & 0xFF;  // Byte 3 of timestamp
+    
+    // Byte 6: Reserved (0x0)
+    frame0.data[6] = 0x00;
+    
+    // Byte 7: Set Position (1-255, 0=no change), valid only when DM is in arm state
+    frame0.data[7] = position;
+    
+    // === TRUNK 1 (Message trunk number 1) ===
+    frame1.id = _can_msg_id;  // Same message ID
+    frame1.dlc = 8;
+    
+    // Byte 0: Sequence number (bits 6-7) and Total trunks (bits 0-5)
+    // Bits 6-7: sequence (0-3) - SAME as trunk 0
+    // Bits 0-5: total_trunks = 2
+    frame1.data[0] = ((_sequence_num & 0x03) << 6) | (2 & 0x3F);
+    
+    // Byte 1: 0x0 (bits 6-7) and Message trunk number (bits 0-5)
+    // Bits 6-7: 0x0
+    // Bits 0-5: trunk_num = 1
+    frame1.data[1] = (0 << 6) | (1 & 0x3F);
+    
+    // Bytes 2-5: Command execution timestamp (little-endian, Byte4-7)
+    frame1.data[2] = (timestamp >> 32) & 0xFF;  // Byte 4 of timestamp
+    frame1.data[3] = (timestamp >> 40) & 0xFF;  // Byte 5 of timestamp
+    frame1.data[4] = (timestamp >> 48) & 0xFF;  // Byte 6 of timestamp
+    frame1.data[5] = (timestamp >> 56) & 0xFF;  // Byte 7 of timestamp
+    
+    // Bytes 6-7: Reserved (0x0)
+    frame1.data[6] = 0x00;
+    frame1.data[7] = 0x00;
+}
+
+// Convert RC input (1000-2000) to position command (1-255)
+uint8_t AP_Gripper_CAN::rc_to_position(uint16_t rc_value)
+{
+    // Constrain input
+    rc_value = constrain_int16(rc_value, RC_MIN, RC_MAX);
+    
+    // Map RC range (1000-2000) to position range (1-255)
+    // Linear interpolation
+    // int32_t position = ((int32_t)(rc_value - RC_MIN) * (POS_MAX - POS_MIN)) / (RC_MAX - RC_MIN) + POS_MIN;
+    if( rc_value <= RC_MIN) {
+        return POS_MIN;
+    } else if (rc_value >= RC_MAX) {
+        return POS_MAX;
+    } 
+    return POS_NEUTRAL;
+}
+
+// #endif  // AP_GRIPPER_ENABLED

--- a/libraries/AP_Gripper/AP_Gripper_CAN.h
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.h
@@ -73,9 +73,6 @@ private:
     // Build ARM state CAN frame (1 trunk)
     void build_arm_frame(bool arm, AP_HAL::CANFrame& frame);
 
-    // Convert RC input to gripper position
-    uint8_t rc_to_position(uint16_t rc_value) ;
-
     // CAN interface for gripper
     AP_HAL::CANIface* _can_iface;
 

--- a/libraries/AP_Gripper/AP_Gripper_CAN.h
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.h
@@ -26,13 +26,11 @@ public:
 
     // grabbed - returns true if gripper in grabbed state
     bool grabbed() const override {
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper CAN grabbed state not implemented yet");
         return false;
     }
 
     // released - returns true if gripper in released state
     bool released() const override {
-        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper CAN released state not implemented yet");
         return false;
     }
 
@@ -90,6 +88,7 @@ private:
     uint8_t _sequence_num;
     uint8_t _current_position;
     uint16_t _last_rc_input;
+    uint32_t action_timestamp;
 
     // CAN message ID (0x320 + board ID)
     uint16_t _can_msg_id;

--- a/libraries/AP_Gripper/AP_Gripper_CAN.h
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.h
@@ -1,0 +1,109 @@
+/*
+ * AP_Gripper_CAN.h
+ *
+ * CAN-based gripper driver for ArduPilot
+ * Sends RC input from Ch8 over CAN bus to control gripper
+ */
+
+#pragma once
+
+#include <AP_Gripper/AP_Gripper_Backend.h>
+#include <AP_CANManager/AP_CANManager.h>
+#define GRIPPER_CAN_TIMEOUT_MS 100  // Timeout for CAN communication
+
+void print_frame(const AP_HAL::CANFrame&);
+
+class AP_Gripper_CAN : public AP_Gripper_Backend {
+public:
+    AP_Gripper_CAN(struct AP_Gripper::Backend_Config &_config);
+        // AP_Gripper_Backend(_config) { };
+
+    // grab - send CAN message to initiate grabbing the cargo
+    void grab() override;
+
+    // release - send CAN message to initiate releasing the cargo
+    void release() override;
+
+    // grabbed - returns true if gripper in grabbed state
+    bool grabbed() const override {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper CAN grabbed state not implemented yet");
+        return false;
+    }
+
+    // released - returns true if gripper in released state
+    bool released() const override {
+        GCS_SEND_TEXT(MAV_SEVERITY_INFO, "Gripper CAN released state not implemented yet");
+        return false;
+    }
+
+    // valid - returns true if the backend should be working
+    bool valid() const override;
+protected:
+    // type-specific intiailisations:
+    void init_gripper() override;
+
+    // type-specific periodic updates:
+    void update_gripper() override;
+private:
+
+    // Creating CAN message
+    struct Gripper_CAN_Message {
+        uint8_t sequence_num : 4;      // Bits 7-4: sequence number (0-3)
+        uint8_t total_trunks : 4;      // Bits 3-0: total number of trunks (2)
+        uint8_t trunk_num_byte1 : 4;   // Byte 1: Bits 7-4: 0x0
+        uint8_t msg_trunk_num : 4;     // Byte 1: Bits 3-0: message trunk number
+        uint32_t timestamp;            // Bytes 2-5: Command execution timestamp (little-endian)
+        uint8_t reserved;              // Byte 6: Reserved (0x0)
+        uint8_t set_pos;               // Byte 7: Set position (1-255, 0=no change)
+    }__attribute__((packed));
+
+    // Send CAN message to gripper
+    bool send_can_message(const uint8_t set_pos);
+
+    // Build CAN frame for gripper control
+    void build_can_frame(uint8_t position, uint8_t trunk_num);
+
+        // Send CAN message with gripper command
+    bool send_position_command(uint8_t position);
+    
+    // Send ARM/DISARM state command
+    bool send_arm_command(bool arm);
+    
+    // Build position control CAN frames (2 trunks)
+    void build_position_frames(uint8_t position, AP_HAL::CANFrame& frame0, AP_HAL::CANFrame& frame1);
+    
+    // Build ARM state CAN frame (1 trunk)
+    void build_arm_frame(bool arm, AP_HAL::CANFrame& frame);
+
+    // Convert RC input to gripper position
+    uint8_t rc_to_position(uint16_t rc_value) ;
+
+    // CAN interface for gripper
+    AP_HAL::CANIface* _can_iface;
+
+    uint8_t _can_driver_index;
+
+    // Gripper state tracking for CAN
+    bool _state_changed;
+    bool _armed;
+    uint32_t _last_send_ms;
+    uint8_t _sequence_num;
+    uint8_t _current_position;
+    uint16_t _last_rc_input;
+
+    // CAN message ID (0x320 + board ID)
+    uint16_t _can_msg_id;
+
+    // Gripper position limits
+    static constexpr uint8_t POS_MIN = 1;
+    static constexpr uint8_t POS_MAX = 255;
+    static constexpr uint8_t POS_NEUTRAL = 0;  // 0 = no change
+    
+    // RC input limits
+    static constexpr uint16_t RC_MIN = 1000;
+    static constexpr uint16_t RC_MAX = 2000;
+    static constexpr uint16_t RC_MID = 1500;
+
+    bool has_state_can(const uint8_t state) const;
+
+};

--- a/libraries/AP_Gripper/AP_Gripper_CAN.h
+++ b/libraries/AP_Gripper/AP_Gripper_CAN.h
@@ -84,7 +84,6 @@ private:
     uint32_t _last_send_ms;
     uint8_t _sequence_num;
     uint8_t _current_position;
-    uint16_t _last_rc_input;
     uint32_t action_timestamp;
 
     // CAN message ID (0x320 + board ID)
@@ -94,11 +93,6 @@ private:
     static constexpr uint8_t POS_MIN = 1;
     static constexpr uint8_t POS_MAX = 255;
     static constexpr uint8_t POS_NEUTRAL = 0;  // 0 = no change
-    
-    // RC input limits
-    static constexpr uint16_t RC_MIN = 1000;
-    static constexpr uint16_t RC_MAX = 2000;
-    static constexpr uint16_t RC_MID = 1500;
 
     bool has_state_can(const uint8_t state) const;
 

--- a/libraries/RC_Channel/RC_Channel.cpp
+++ b/libraries/RC_Channel/RC_Channel.cpp
@@ -857,6 +857,7 @@ void RC_Channel::do_aux_function_gripper(const AuxSwitchPos ch_flag)
 {
     AP_Gripper *gripper = AP::gripper();
     if (gripper == nullptr) {
+        GCS_SEND_TEXT(MAV_SEVERITY_WARNING, "Gripper not configured");
         return;
     }
 


### PR DESCRIPTION
The objective of this PR is to have a redundancy channel to communicate with the Drop Mech using the CAN2 Network for Project O as designed by KL.
For this PR I have created a new driver for Gripper which is **GRIP_TYPE : 3**.
Now this will communicate the following packets to the GRIPPER as instructed by KL:
<img width="501" height="217" alt="image" src="https://github.com/user-attachments/assets/1ce53e83-3d5e-4af3-ac6d-3c18a735bd32" />
<img width="470" height="124" alt="image" src="https://github.com/user-attachments/assets/edaa01e9-e3e0-4dc7-834c-fa3171c4f5e8" />
<img width="470" height="150" alt="image" src="https://github.com/user-attachments/assets/66b5f477-b3ad-402a-82c9-b49e06fb4e91" />

Expectation from the C2 is that it validates the Arm-Disarm to send the Drop instructions:
<img width="1031" height="598" alt="image" src="https://github.com/user-attachments/assets/d75c4038-1c09-4702-bc46-2d1bacd9a692" />

The dev logs for this is:
[devlog_drop_mech_can.docx](https://github.com/user-attachments/files/25762248/devlog_drop_mech_can.docx)
