### PR TITLE
Imu internal error fix icm20602

### DIFF
--- a/ArduCopter/version.h
+++ b/ArduCopter/version.h
@@ -6,7 +6,7 @@
 
 #include "ap_version.h"
 
-#define THISFIRMWARE "MA_COPTER-V4.3.0.12"
+#define THISFIRMWARE "MA_COPTER-V4.3.0.13"
 
 // the following line is parsed by the autotest scripts
 #define FIRMWARE_VERSION 4, 3, 0, FIRMWARE_VERSION_TYPE_OFFICIAL

--- a/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.inc
+++ b/libraries/AP_HAL_ChibiOS/hwdef/CubeOrange/hwdef.inc
@@ -340,3 +340,5 @@ define HAL_ADSB_SAGETECH_MXS_ENABLED HAL_ADSB_ENABLED
 # note that if firmware is build with --secure-bl then DFU is
 # disabled
 ENABLE_DFU_BOOT 1
+
+define HAL_ENABLE_FAST_FIFO_RESET_ICM20602 1

--- a/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
+++ b/libraries/AP_InertialSensor/AP_InertialSensor_Invensense.h
@@ -86,6 +86,8 @@ private:
 
     void _set_filter_register(void);
     void _fifo_reset(bool log_error) __RAMFUNC__;
+    void _fast_fifo_reset() __RAMFUNC__;
+
     bool _has_auxiliary_bus();
 
     /* Read samples from FIFO (FIFO enabled) */
@@ -129,11 +131,17 @@ private:
     LowPassFilter2pFloat _temp_filter;
     uint32_t last_reset_ms;
     uint8_t reset_count;
+    uint8_t fast_reset_count;
+    uint8_t last_fast_reset_count;
+    uint32_t last_fast_reset_count_report_ms;
 
     enum Rotation _rotation;
 
     // enable checking of unexpected resets of offsets
     bool _enable_offset_checking;
+
+    // enable fast fifo reset instead of full fifo reset
+    bool _enable_fast_fifo_reset;
 
     // ICM-20602 y offset register. See usage for explanation
     uint8_t _saved_y_ofs_high;


### PR DESCRIPTION
Issue: 
We observed the following internal error for pre bench:
<img width="238" height="64" alt="image" src="https://github.com/user-attachments/assets/204f3419-c19e-4f4f-8418-1e37363e26ba" />

The Error Code 0x1000000 is for imu reset.
Known issue from before:
[Internal Error Discord](https://github.com/ArduPilot/ardupilot/issues/25142)

The reason this reset happens is because of  fifo_reset:
```
void AP_InertialSensor_Invensense::_fifo_reset(bool log_error)
{
    uint32_t now = AP_HAL::millis();
    if (log_error &&
        !hal.scheduler->in_expected_delay() &&
        now - last_reset_ms < 10000) {
        reset_count++;
        if (reset_count == 10) {
            // 10 resets, each happening within 10s, triggers an internal error
            INTERNAL_ERROR(AP_InternalError::error_t::imu_reset);
            reset_count = 0;
        }
````

There is already a fix in the main branch 4.3.3, which is a fast reset.

The impacted IMU as per our hardware is ICM20602: 
<img width="888" height="639" alt="image" src="https://github.com/user-attachments/assets/f57dea8f-8cb6-43a1-8d19-55d55569fb4a" />



Please see the Cherry picks below

Testing done:
Gry-X for IMU 0,1, and 2:

<img width="1850" height="843" alt="image" src="https://github.com/user-attachments/assets/c1743181-76bd-47f9-9897-26717dc74aaf" />


Gry-Y for IMU0,1,2

<img width="1892" height="903" alt="image" src="https://github.com/user-attachments/assets/40e689f7-93b6-4636-a827-80e74cde406a" />

Gry-Z for IMU0,1,2

<img width="1864" height="859" alt="image" src="https://github.com/user-attachments/assets/e1a4af65-1379-4f0c-8cbf-8cc7980c924b" />



AccX IMU 0,1,2

<img width="1824" height="907" alt="image" src="https://github.com/user-attachments/assets/cc141ac3-bd53-4ba7-8b01-d4fe8b2c8a03" />

AccY IMU0,1,2

<img width="1843" height="876" alt="image" src="https://github.com/user-attachments/assets/4fafcc72-3c0f-4733-9891-e75275a8f1f5" />

AccZ IMU0,1,2

<img width="1892" height="874" alt="image" src="https://github.com/user-attachments/assets/16333609-0b46-477a-a54c-8f7bc19ef263" />
