### PR TITLE
Feature/keep build artefacts

### DIFF
--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -296,3 +296,11 @@ jobs:
           name: BIN-${{matrix.config}}
           path: /__w/ardupilot/ardupilot/logs
           retention-days: 7
+
+      - name: Archive SITL build
+        uses: actions/upload-artifact@v5
+        with:
+          name: SITL-${{ matrix.config }}
+          path: |
+            build/sitl
+          retention-days: 7

--- a/.github/workflows/test_sitl_copter.yml
+++ b/.github/workflows/test_sitl_copter.yml
@@ -267,11 +267,11 @@ jobs:
         run: |
           git config --global --add safe.directory ${GITHUB_WORKSPACE}
 
-		  python3 -m pip install --upgrade \
-    	    pymavlink==2.4.49 \
-    		MAVProxy==1.8.74
+          python3 -m pip install --upgrade \
+            pymavlink==2.4.49 \
+            MAVProxy==1.8.74
 
-		  python3 -m pip freeze | grep -E "MAVProxy|pymavlink"
+          python3 -m pip freeze | grep -E "MAVProxy|pymavlink"
 
           PATH="/github/home/.local/bin:$PATH"
           Tools/scripts/build_ci.sh

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -65,8 +65,8 @@ jobs:
       matrix:
         toolchain: [chibios]
         config: [MatekH743, mRoControlZeroOEMH7, CubeOrange]
-	env:
-		BASE_BRANCH: ${{ github.event.pull_request.base.ref || 'MA-4.3.0.X' }}
+    env:
+      BASE_BRANCH: ${{ github.event.pull_request.base.ref || 'MA-4.3.0.X' }}
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -241,9 +241,9 @@ jobs:
           fi
 
       - name: Upload firmware
-	    uses: actions/upload-artifact@v4
-		with:
-		  name: firmware-${{ matrix.config }}
-		  path: |
-			${{ github.workspace }}/pr_bin
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.config }}
+          path: |
+            ${{ github.workspace }}/pr_bin
 

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -65,10 +65,13 @@ jobs:
       matrix:
         toolchain: [chibios]
         config: [MatekH743, mRoControlZeroOEMH7, CubeOrange]
+	env:
+		BASE_BRANCH: ${{ github.event.pull_request.base.ref || 'MA-4.3.0.X' }}
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.base.ref }}
+          #ref: ${{ github.event.pull_request.base.ref }}
+          ref: ${{ env.BASE_BRANCH }}
           path: base_branch
           submodules: 'recursive'
       # Put ccache into github cache for faster build
@@ -86,7 +89,8 @@ jobs:
       - name: setup ccache
         run: |
           . base_branch/.github/workflows/ccache.env
-      - name: Build ${{ github.event.pull_request.base.ref }} ${{matrix.config}} ${{ matrix.toolchain }}
+      #- name: Build ${{ github.event.pull_request.base.ref }} ${{matrix.config}} ${{ matrix.toolchain }} 
+      - name: Build ${{ env.BASE_BRANCH }} ${{matrix.config}} ${{ matrix.toolchain }}
         env:
           CI_BUILD_TARGET: ${{matrix.config}}
         shell: bash
@@ -114,7 +118,8 @@ jobs:
 
           # build a set of binaries without symbols so we can check if
           #  the binaries have changed.
-          echo [`date`] Building ${{ github.event.pull_request.base.ref }} with no versions
+          #echo [`date`] Building ${{ github.event.pull_request.base.ref }} with no versions
+          echo [`date`] Building ${{ env.BASE_BRANCH }} with no versions
 
           NO_VERSIONS_DIR="$GITHUB_WORKSPACE/base_branch_bin_no_versions"
           mkdir "$NO_VERSIONS_DIR"
@@ -130,7 +135,8 @@ jobs:
 
           cp -r $BIN_SRC/* "$NO_VERSIONS_DIR"
 
-          echo [`date`] Built ${{ github.event.pull_request.base.ref }} with no versions
+          #echo [`date`] Built ${{ github.event.pull_request.base.ref }} with no versions
+          echo [`date`] Built ${{ env.BASE_BRANCH }} with no versions
 
       - uses: actions/checkout@v6
         with:
@@ -192,7 +198,8 @@ jobs:
           cd pr/
           Tools/scripts/build_tests/pretty_diff_size.py -m $GITHUB_WORKSPACE/base_branch_bin_no_versions -s $GITHUB_WORKSPACE/pr_bin_no_versions
 
-      - name: Feature compare with  ${{ github.event.pull_request.base.ref }}
+      #- name: Feature compare with  ${{ github.event.pull_request.base.ref }}
+      - name: Feature compare with  ${{ env.BASE_BRANCH }}
         shell: bash
         run: |
           set -ex
@@ -218,7 +225,8 @@ jobs:
             echo "No differences found." >> $GITHUB_STEP_SUMMARY
           fi
 
-      - name: Binary compare with ${{ github.event.pull_request.base.ref }}
+      #- name: Binary compare with ${{ github.event.pull_request.base.ref }}
+      - name: Binary compare with ${{ env.BASE_BRANCH }}
         shell: bash
         run: |
           diff -r $GITHUB_WORKSPACE/base_branch_bin_no_versions $GITHUB_WORKSPACE/pr_bin_no_versions --exclude=*.abin --exclude=*.apj || true

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -231,3 +231,11 @@ jobs:
           else
             echo "No differences found." >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Upload firmware
+	    uses: actions/upload-artifact@v4
+		with:
+		  name: firmware-${{ matrix.config }}
+		  path: |
+			${{ github.workspace }}/pr_bin
+

--- a/.github/workflows/test_size.yml
+++ b/.github/workflows/test_size.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false # don't cancel if a job from the matrix fails
       matrix:
         toolchain: [chibios]
-        config: [MatekH743, mRoControlZeroOEMH7, CubeOrange]
+        config: [MatekH743, mRoControlZeroOEMH7, CubeOrange, sitl]
     env:
       BASE_BRANCH: ${{ github.event.pull_request.base.ref || 'MA-4.3.0.X' }}
     steps:

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -172,9 +172,9 @@ jobs:
           retention-days: 14
 
       - name: Archive SITL build
+        if: always() && matrix.config == 'sitl'
         uses: actions/upload-artifact@v5
         with:
-          name: SITL-${{ matrix.config }}
-          path: |
-            build/sitl
+          name: SITL-${{ matrix.toolchain }}
+          path: build/sitl
           retention-days: 7

--- a/.github/workflows/test_unit_tests.yml
+++ b/.github/workflows/test_unit_tests.yml
@@ -170,3 +170,11 @@ jobs:
           name: fail-${{ matrix.toolchain }}-${{matrix.config}}
           path: /tmp/buildlogs
           retention-days: 14
+
+      - name: Archive SITL build
+        uses: actions/upload-artifact@v5
+        with:
+          name: SITL-${{ matrix.config }}
+          path: |
+            build/sitl
+          retention-days: 7


### PR DESCRIPTION
The purpose of this tweak to the GitHub Workflows scripts is to preserve and make accessible for download the compiled binaries for our supported hardware platforms and SITL.

This change has no effect whatsoever on the ArduPilot firmware itself, bench/flight testing is not required.